### PR TITLE
fixed typo in about > contributing.rst 

### DIFF
--- a/about/contributing.rst
+++ b/about/contributing.rst
@@ -80,7 +80,7 @@ advanced users.
 
 * Check that you do not have any syntax errors or typos
 
-* Commit changes your changes and `create <https://help.github.com/articles/creating-a-pull-request>`_ and open `pull <https://help.github.com/articles/using-pull-requests>`_ request.
+* Commit your changes and `create <https://help.github.com/articles/creating-a-pull-request>`_ and open `pull <https://help.github.com/articles/using-pull-requests>`_ request.
 
 For more information about writing documentation please read the :doc:`styleguide </about/styleguide>` and also :doc:`this </about/helper_tools>`.
 


### PR DESCRIPTION
under the 'editing the documentation using git' section, the word 'changes' occurs one too many times.
