### PR TITLE
Fixed a typo in the query-by-date section

### DIFF
--- a/develop/plone/searching_and_indexing/query.rst
+++ b/develop/plone/searching_and_indexing/query.rst
@@ -708,7 +708,7 @@ See `DateIndex <http://svn.zope.org/Zope/trunk/src/Products/PluginIndexes/DateIn
 
 Example::
 
-    items = portal_catalog(effective_date = {'date': {'query':(DateTime('2002-05-08 15:16:17'),
+    items = portal_catalog(effective_date = {'query':(DateTime('2002-05-08 15:16:17'),
                                             DateTime('2062-05-08 15:16:17')),
                                    'range': 'min:max'})
 


### PR DESCRIPTION
In this case

{'date': {'query':

should just be

{'query':

There was a closing bracket mismatch as well.  The corrected code is valid catalog query syntax.
