### PR TITLE
[ci skip] Extends spellcheck, pypi packages or ok

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -34,8 +34,11 @@ extensions = [
     'sphinxcontrib.spelling',
 ]
 
+# Spellcheck
 # This is our wordlist with know words, like Github or Plone ...
 spelling_word_list_filename='spelling_wordlist.txt'
+#Controlling whether words that look like package names from PyPI are treated as spelled properly
+spelling_ignore_pypi_package_names=True
 
 # Enable Robot Framework tests during Sphinx compilation:
 sphinxcontrib_robotframework_enabled = True  # 'True' is the default


### PR DESCRIPTION
This adds:
spelling_ignore_pypi_package_names=True
    Boolean controlling whether words that look like package names from PyPI are treated as spelled properly. When True, the current list of package names is downloaded at the start of the build and used to extend the list of known words in the dictionary. Defaults to False.
