### PR TITLE
[ci skip] Exclude external/plone.api/docs/CHANGES.rst 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -86,7 +86,7 @@ release = '4.3'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['README.rst', '_*.rst']
+exclude_patterns = ['README.rst', '_*.rst', 'external/plone.api/docs/CHANGES.rst']
 
 # Announce that we have a opensearch plugin
 html_use_opensearch = 'http://docs.plone.org'


### PR DESCRIPTION
with this exclude rule, we have less build warnings, because we tell sphinx to ignore this file
