### PR TITLE
Remove Plone unit-testing tutorial link.

### DIFF
--- a/manage/deploying/testing_tuning/testing_and_debugging/unit_testing.rst
+++ b/manage/deploying/testing_tuning/testing_and_debugging/unit_testing.rst
@@ -12,8 +12,6 @@ add-on product is intact in the current product configuration. Unit tests
 are regression tests and are designed to catch broken functionality over the
 code evolution.
 
-`Plone unit testing tutorial <http://plone.org/documentation/tutorial/richdocument/unit-testing>`_.
-
 Running unit tests
 ===================
 


### PR DESCRIPTION
The link redirects to a restrict and old knowledge base document[1]. 
- requires plone.org site authentication
- it is old, refers to the 2.1 version.  

[1] - https://plone.org/documentation/kb-old/richdocument/unit-testing
