### PR TITLE
update validators page with a little more information

### DIFF
--- a/develop/plone/content/archetypes/validators.rst
+++ b/develop/plone/content/archetypes/validators.rst
@@ -17,6 +17,10 @@ List of default validators
 Creating a validator
 -----------------------
 
+A custom validator should return True if valid, or an error string if validation fails.
+This is especially important to remember when chaining validators together.
+See the tutorials below for further details:
+
 * http://play.pixelblaster.ro/blog/archive/2006/08/27/creating-an-archetypes-validator
 
 * http://www.pererikstrandberg.se/blog/index.cgi?page=PloneArchetypesFieldValidator


### PR DESCRIPTION
The first line added is only mentioned in a doc string in one of the tutorials. This bit me quiet badly when trying to chain validators together. It's worth putting on this page explicitly. 
