### PR TITLE
Correct sample Content Security Policy for Nginx

### DIFF
--- a/manage/deploying/front-end/nginx.rst
+++ b/manage/deploying/front-end/nginx.rst
@@ -58,8 +58,8 @@ Create file ``/etc/nginx/sites-available/yoursite.conf`` with contents::
     add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Content-Type-Options "nosniff";
-    #add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'unsafe-eval'";
-    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src *; style-src 'unsafe-inline'; script-src 'unsafe-inline' 'unsafe-eval'";
+    #add_header Content-Security-Policy "default-src 'self'; img-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'";
+    add_header Content-Security-Policy-Report-Only "default-src 'self'; img-src *; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval'";
 
     # This specifies which IP and port Plone is running on.
     # The default is 127.0.0.1:8080


### PR DESCRIPTION
This eliminates errors like this in my browser (Firefox) console:
Content Security Policy: The page's settings observed the loading of a resource at my.plonesite.com/..../reset.css

The error may have been because "There is also no inheritance from the default source directive."
( as noted at https://scotthelme.co.uk/content-security-policy-an-introduction/#creatingapolicy)

See also: https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet

Same would presumably apply for Apache, but I haven't tested that.
