### PR TITLE
Update Travis CI -configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,22 @@
 language: python
-python: '2.7'
+python:
+- 2.7
+sudo: false
 before_install:
-- sudo apt-get update -qq
-- sudo apt-get install -qq enchant
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
+- curl -O http://www.abisource.com/downloads/enchant/1.6.0/enchant-1.6.0.tar.gz
+- tar xzvf enchant-1.6.0.tar.gz
+- cd enchant-1.6.0
+- ./configure --prefix=`pwd`
+- make install
+- cd ..
 install:
 - git clone https://github.com/plone/papyrus ../papyrus && cd ../papyrus
 - mkdir -p source && ln -s ../../documentation source/documentation
 - mkdir -p buildout-cache/downloads
-- virtualenv buildout
-- buildout/bin/python bootstrap.py -c travis.cfg
-- bin/buildout -N -t 3 -c travis.cfg buildout:checkout=documentation sources:documentation="fs
+- python bootstrap-buildout.py
+- bin/buildout -N -t 3 buildout:checkout=documentation sources:documentation="fs
   documentation egg=false"
 before_script:
 - gem install --version 0.8.9 faraday
@@ -21,6 +26,9 @@ script:
 after_script:
 - travis-artifacts upload --path build/html
 - travis-artifacts upload --target-path latest --path build/html
+cache:
+  directories:
+  - eggs
 notifications:
   irc:
     channels:
@@ -30,6 +38,7 @@ notifications:
     - ! 'Sphinx: http://plone-documentation.s3-website-us-east-1.amazonaws.com/artifacts/%{build_number}/%{build_number}.1/en/'
 env:
   global:
+  - LD_LIBRARY_PATH=`pwd`/enchant-1.6.0/lib
   - ARTIFACTS_S3_BUCKET=plone-documentation
   - secure: B1NL93YgevEmUmvogdnq6Cz1GFvsFiYyCIv6yvudss2f9jzX1nzolbXiH8bFDwJnNQmkzFSm+fzWRDCSvoO8KnvLHTOjsrlcLQ6Er9A/vNQU1DgBvoqxBI7Y+h8OrTzhGK7YENAD/1PkSXmt/OAji/YKJNSULTawpGN1hGBfEio=
   - secure: Bn6H7ckcLTZrR73FcoqWH2ukzlQKGyDyFFAPN9FbJ0/gPH3a/6XLMe59WH6pYcvzxotxfvaQEloTuXnJvjn/f7lTkRHU1Z+DbymdmXuhNCv0meMwg0EhSKiqfYpUqhs/1Jn/fqUnxcFu66Ts905DKs1fnBbWHG5+JmVkslFaRSo=


### PR DESCRIPTION
Should fix Travis CI -build (with build cache, which should speed up the builds after a few runs)

Build cache in Travis is only allowed for public repo builds without sudo, which requires enchant to be build locally.