### PR TITLE
Remove bogus CMFCore line at end of page.

### DIFF
--- a/manage/upgrading/version_specific_migration/p40_to_p41_upgrade.rst
+++ b/manage/upgrading/version_specific_migration/p40_to_p41_upgrade.rst
@@ -124,5 +124,3 @@ If you need to be backward compatible you can add repositorytool.xml (which will
     except ImportError:
         # repositorytool.xml will be used
         pass
-
-<include package="Products.CMFCore" />


### PR DESCRIPTION
This line is used earlier on the page.  Seems an unwanted copy action
or a small error while first adding this page.