### PR TITLE
Fix post-login-event example

### DIFF
--- a/develop/plone/sessions/login.rst
+++ b/develop/plone/sessions/login.rst
@@ -173,6 +173,7 @@ a custom folder after he/she logs in (overrides standard Plone login behavior)
     from AccessControl import getSecurityManager
     from zope.interface import Interface
     from zope.component import getUtility
+    from zope.app.component.hooks import getSite
     from zope.globalrequest import getRequest
 
     # CMFCore imports

--- a/develop/plone/sessions/login.rst
+++ b/develop/plone/sessions/login.rst
@@ -173,7 +173,7 @@ a custom folder after he/she logs in (overrides standard Plone login behavior)
     from AccessControl import getSecurityManager
     from zope.interface import Interface
     from zope.component import getUtility
-    from zope.app.component.hooks import getSite
+    from zope.globalrequest import getRequest
 
     # CMFCore imports
     from Products.CMFCore import permissions
@@ -241,14 +241,11 @@ a custom folder after he/she logs in (overrides standard Plone login behavior)
 
         url = redirect_to_edit_access_folder(user)
         if url:
-            # We need to access the HTTP request object via
-            # acquisition as it is not exposed by the event
-            portal = getSite()
-            request = getattr(portal, "REQUEST", None)
-            if not request:
+            request = getRequest()
+            if request is None:
                 # HTTP request is not present e.g.
                 # when doing unit testing / calling scripts from command line
-                return None
+                return
 
             # check if came_from is not empty, then clear it up, otherwise further
             # Plone scripts will override our redirect

--- a/develop/plone/sessions/login.rst
+++ b/develop/plone/sessions/login.rst
@@ -145,8 +145,21 @@ PluggableAuthService service.
 
 * ``IUserLoggedOutEvent``
 
-Here is an :doc:`Grok based </appendices/grok>` example how to redirect a user to
+Here is an example how to redirect a user to
 a custom folder after he/she logs in (overrides standard Plone login behavior)
+
+``configure.zcml``::
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        i18n_domain="my.package">
+
+        <subscriber
+            for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"
+            handler=".postlogin.logged_in_handler"
+            />
+
+    </configure>
 
 ``postlogin.py``::
 
@@ -164,10 +177,6 @@ a custom folder after he/she logs in (overrides standard Plone login behavior)
 
     # CMFCore imports
     from Products.CMFCore import permissions
-    from Products.PluggableAuthService.interfaces.events import IUserLoggedInEvent
-
-    # Caveman imports
-    from five import grok
 
     # Plone imports
     from Products.CMFPlone.interfaces.siteroot import IPloneSiteRoot
@@ -223,7 +232,6 @@ a custom folder after he/she logs in (overrides standard Plone login behavior)
         return None
 
 
-    @grok.subscribe(IUserLoggedInEvent)
     def logged_in_handler(event):
         """
         Listen to the event and perform the action accordingly.


### PR DESCRIPTION
Dragging over https://github.com/collective/collective.developermanual/pull/255

Unless I'm missing something, the example as-was made no sense. The return value of redirect_to_edit_access_folder wasn't even used. Steal the relevant chunk of code out of collective.onlogon to make it do what I think is something reasonable.

Also, remove grok whilst here.

This could be simplified further by removing the code to find the user folder (which isn't strictly relevant), but maybe this is useful for people? At very least, I've tried to separate the user-folder-finding part and the core of redirecting to a page on login.