### PR TITLE
Update link

### DIFF
--- a/develop/plone/security/local_roles.rst
+++ b/develop/plone/security/local_roles.rst
@@ -76,7 +76,7 @@ manage the particular role.
 Setting local role
 ===================
 
-``manage_setLocalRoles`` is defined in `AccessControl.Role.RoleManager <http://svn.zope.org/Zope/trunk/src/AccessControl/Role.py?rev=96262&view=markup>`_.
+``manage_setLocalRoles`` is defined in `AccessControl.rolemanager.RoleManager <https://github.com/zopefoundation/AccessControl/blob/master/src/AccessControl/rolemanager.py#L339>`_.
 
 Example::
 


### PR DESCRIPTION
Update a link from svn to github and update its location as the old
reference is deprecated.

Question: the old location the link is pointing to: https://github.com/zopefoundation/AccessControl/blob/master/src/AccessControl/Role.py where a deprecated warning message talks about OFS.role:RoleManager as well as AccessControl.rolemanager, which one should be the one we document? I choosed AccessControl one as OFS is still calling a lower-level  manage_setLocalRoles which I guess goes to AccessControl.

Opinions welcome!

Another question for @svx: should I make (once the question above is clear) another pull request for master branch? How branching is handled for patches right now? Should I make another patch for branch 3.3?