### PR TITLE
Add link to zope.component docs

### DIFF
--- a/develop/plone/forms/vocabularies.rst
+++ b/develop/plone/forms/vocabularies.rst
@@ -358,4 +358,7 @@ Then you can refer to vocabulary by its name::
 
         area = schema.Choice(source="garys-favorite-path-references", title=_("Area"), required=False)
 
-For more information see `vocabularies API doc <http://docs.zope.org/zope3/ZCML/http_co__sl__sl_namespaces.zope.org_sl_zope/vocabulary/index.html>`_.
+For more information see:
+
+* `vocabularies API doc <http://docs.zope.org/zope3/ZCML/http_co__sl__sl_namespaces.zope.org_sl_zope/vocabulary/index.html>`_ 
+* `zope.component docs <https://raw.githubusercontent.com/zopefoundation/zope.component/master/docs/zcml.rst>`_


### PR DESCRIPTION
I'm not sure how to put this actually, but the link I added shows that you can also register utilities, and so vocabularies with a factory.  "... In this case, the ZCML handler calls the factory (without any arguments) and registers the returned value as a utility.  Typically, you'd pass a class for the factory".

So a registration such as the one below is valid:

    <utility
        factory=".vocabularies.RowStylesVocabulary"
        provides="zope.schema.interfaces.IVocabularyFactory"
        name="collective.cover.RowColumnStyles"
        />