### PR TITLE
no :term: in headers, and deleting an invisible utf-8 char

### DIFF
--- a/about/helper_tools.rst
+++ b/about/helper_tools.rst
@@ -73,8 +73,9 @@ Language tools:
 
 These tools can help you to check for grammatical mistakes and typos, you should always use a spell checker anyway!
 
-**LanguageTool** `is an Open Source proof­reading software for English, French, German, Polish, and more than 20 other languages <https://www.languagetool.org/>`_.
+**LanguageTool** is an Open Source proofreading software for English, French, German, Polish and more than 20 other languages.
+See `www.languagetool.org <https://www.languagetool.org/>`_.
 
-**After the Deadline** `is a language checker for the web <http://www.afterthedeadline.com/>`_. 
+**After the Deadline** `is a language checker for the web <http://www.afterthedeadline.com/>`_.
 This handy tool is also available in your Plone sites, by the way, see the :doc:`conent quality </working-with-content/content-quality/index>` section
 

--- a/about/helper_tools.rst
+++ b/about/helper_tools.rst
@@ -53,7 +53,7 @@ Another nice tool for Emacs is `Flycheck <https://flycheck.readthedocs.org/en/la
 Marketplace.
 
 **Vim** does syntax highlighting for RST files.
-There is a nice plugin called `vim-markdown <https://github.com/plasticboy/vim-markdown>`.
+There is a nice plugin called `vim-markdown <https://github.com/plasticboy/vim-markdown>`_.
 
 If you prefer a more *advanced* plugin with enhanced functionalities you could use `Riv <https://github.com/Rykka/riv.vim>`_.
 

--- a/about/helper_tools.rst
+++ b/about/helper_tools.rst
@@ -44,10 +44,8 @@ There is also a `online version <http://johnmacfarlane.net/pandoc/try/>`_.
 
 One  particular which is really good for getting a impression how it will looks like in html is `OmniMarkupPreviewer <https://sublime.wbond.net/packages/OmniMarkupPreviewer>`_ a live previewer/exporter for markup files (markdown, rst, creole, textile...).
 
-**Emacs** has a nice `rst-mode
-<http://docutils.sourceforge.net/docs/user/emacs.html>`_. This mode comes
-with some Emacs distros. Try ``M-x rst-mode`` in your Emacs and enjoy syntax
-coloration, underlining a heading with ``^C ^A``
+**Emacs** has a nice `rst-mode <http://docutils.sourceforge.net/docs/user/emacs.html>`_.
+This mode comes with some Emacs distros. Try ``M-x rst-mode`` in your Emacs and enjoy syntax coloration, underlining a heading with ``^C ^A``
 
 Another nice tool for Emacs is `Flycheck <https://flycheck.readthedocs.org/en/latest/index.html>`_.
 
@@ -55,11 +53,9 @@ Another nice tool for Emacs is `Flycheck <https://flycheck.readthedocs.org/en/la
 Marketplace.
 
 **Vim** does syntax highlighting for RST files.
-There is a nice plugin called `vim-markdown
-<https://github.com/plasticboy/vim-markdown>`.
+There is a nice plugin called `vim-markdown <https://github.com/plasticboy/vim-markdown>`.
 
-If you prefer a more *advanced* plugin with enhanced functionalities you could
-use `Riv <https://github.com/Rykka/riv.vim>`_.
+If you prefer a more *advanced* plugin with enhanced functionalities you could use `Riv <https://github.com/Rykka/riv.vim>`_.
 
 **Restview** `ReStructuredText viewer <https://pypi.python.org/pypi/restview>`_
 A viewer for ReStructuredText documents that renders them on the fly.

--- a/develop/addons/components/zcml.rst
+++ b/develop/addons/components/zcml.rst
@@ -9,7 +9,7 @@
 .. contents :: :local:
 
 Introduction
-=================
+============
 
 :term:`ZCML` stands for the *Zope Configuration Mark-up Language*.  It is an
 XML-based language used to extend and plug into systems based on the Zope
@@ -146,8 +146,8 @@ But using the full path in dotted notation, you can let it point to your
 own class.
 
 
-Conditionally run :term:`ZCML`
-===============================
+Conditionally run ZCML
+======================
 
 You can conditionally run :term:`ZCML` if a certain package or feature is
 installed.


### PR DESCRIPTION
latex / PDF generation was failing. To note: there really shouldn't be :term: statements in headers, it confuses sphinx. And we should find a way to look for invisible utf-8 chars (this one was \u8, or non-breaking space, that Macs tend to generate when hitting Option-Space)