### PR TITLE
Bobtemplates p4

### DIFF
--- a/develop/addons/bobtemplates.rst
+++ b/develop/addons/bobtemplates.rst
@@ -1,0 +1,120 @@
+=========================================
+Bootstrapping Plone add-on development
+=========================================
+
+``bobtemplates.plone`` provides a `mr.bob <http://mrbob.readthedocs.org/en/latest/>`_ template to generate packages for Plone projects.
+
+To create a package like ``collective.myaddon``::
+
+    $ mrbob -O collective.myaddon bobtemplates:plone_addon
+
+You can also create a package with nested namespace::
+
+    $ mrbob -O collective.foo.myaddon bobtemplates:plone_addon
+
+
+Options
+=======
+
+On creating a package you can choose from the following options. The default value is in [square brackets]:
+
+
+Author's name
+    Should be something like 'John Smith'.
+
+Author's email
+    Should be something like 'john@plone.org'.
+
+Author's github username
+    Should be something like 'john'.
+
+Package description [An add-on for Plone]
+    One-liner describing what this package does. Should be something like 'Plone add-on that ...'.
+
+Package keywords [Plone Python]
+    Keywords/categoris describing this package. Should be something like 'Plone Python Diazo...'.
+
+Version of the package [0.1]
+    Should be something like '0.1'.
+
+License of the package [GPL]
+    Should be something like 'GPL'.
+
+Plone version [4.3.4]
+    Which Plone version would you like to use?
+
+Add locales? [False]
+    Do you want to add translations to this package?
+
+Add example view? [True]
+    Do you want to register a browser view 'demoview' as an example?
+
+Use generic setup profile? [True]
+    Do you want the package to have a generic setup profile? If you select False all following questions will be skipped.
+
+Add setuphandlers? [True]
+    Do you want the package to have a setuphander.py to run cusotm code during install?
+
+Add a diazo-theme? [False]
+    Do you want to add a empty theme using diazo/plone.app.theming to the package?
+
+Add tests? [True]
+    Do you want to add a basic setup for tests, robot-tests and travis-integration?
+
+Prepare Travis Integration? [False]
+    Should the package be prepared to be integrated into travis (http://travis-ci.org)? If you select False all following questions will be skipped.
+
+Type of Travis CI notifications [email]
+    Should be something like 'email' or 'irc', see : http://about.travis-ci.org/docs/user/notifications for more information.
+
+Destination for Travis CI notifications
+    Should be something like 'travis-reports@example.com' or 'irc.freenode.org#plone'.
+
+
+Compatibility
+=============
+
+Addons created with ``bobtemplates.plone`` are tested to work in Plone 4.3.x and Plone 5.
+They should also work with older versions but that was not tested.
+
+
+Installation
+============
+
+Use in a buildout
+-----------------
+
+::
+
+    [buildout]
+    parts += mrbob
+
+    [mrbob]
+    recipe = zc.recipe.egg
+    eggs =
+        mr.bob
+        bobtemplates.plone
+
+
+This creates a mrbob-executeable in your bin-directory.
+Call it from the ``src``-directory of your Plone project like this.::
+
+    $ ../bin/mrbob -O collective.foo bobtemplates:plone_addon
+
+
+Installation in a virtualenv
+----------------------------
+
+You can also install ``bobtemplates.plone`` in a virtualenv.::
+
+    $ pip install mr.bob
+
+    $ pip install bobtemplates.plone
+
+Now you can use it like this::
+
+    $ mrbob -O collective.foo bobtemplates:plone_addon
+
+See `mr.bobi <http://mrbob.readthedocs.org/en/latest/>`_ documentation for further information.
+
+

--- a/develop/addons/components/customizing_plone.rst
+++ b/develop/addons/components/customizing_plone.rst
@@ -34,7 +34,7 @@ need go through manual steps to achieve the same customization.
 
 Possible through-the-web changes are:
 
-* Site settings: E.g. adding/removing `content rules <https://plone.org/documentation/how-to/content-rules>`_
+* Site settings: E.g. adding/removing `content rules </working-with-content/managing-content/contentrules>`_
 
 * Showing and hiding viewlets (parts of the page) using ``@@manage-viewlets``
 
@@ -52,12 +52,8 @@ Through the code changes
 
 To expand Plone using Python, you have to create your own add-on product.
 Add-on products are distributed as packaged Python modules called :doc:`eggs </old-reference-manuals/buildout/index>`.
-The recommended way is to use the :doc:`paster </develop/addons/paste>` command to generate an add-on
+The recommended way is to use the :doc:`bobtemplates </develop/addons/bobtemplates>` command to generate an add-on
 product skeleton which you can
 use as a starting point for your development.
-Paster also contains useful subcommands, like ``addcontent``,
-which automate various Plone add-on development tasks.
-
-* Another `paster tutorial <http://www.unc.edu/~jj/plone/>`_
 
 

--- a/develop/addons/components/customizing_plone.rst
+++ b/develop/addons/components/customizing_plone.rst
@@ -48,11 +48,11 @@ Possible through-the-web changes are:
   interface and registering using ``portal_css`` and ``portal_javascripts``
 
 Through the code changes
-==========================
+========================
 
 To expand Plone using Python, you have to create your own add-on product.
 Add-on products are distributed as packaged Python modules called :doc:`eggs </old-reference-manuals/buildout/index>`.
-The recommended way is to use the :doc:`bobtemplates </develop/addons/bobtemplates>` command to generate an add-on
+The recommended way is to use the :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` command to generate an add-on
 product skeleton which you can
 use as a starting point for your development.
 

--- a/develop/addons/components/customizing_plone.rst
+++ b/develop/addons/components/customizing_plone.rst
@@ -34,7 +34,7 @@ need go through manual steps to achieve the same customization.
 
 Possible through-the-web changes are:
 
-* Site settings: E.g. adding/removing `content rules </working-with-content/managing-content/contentrules>`_
+* Site settings: E.g. adding/removing :doc:`content rules </working-with-content/managing-content/contentrules>`
 
 * Showing and hiding viewlets (parts of the page) using ``@@manage-viewlets``
 

--- a/develop/addons/dexterity.rst
+++ b/develop/addons/dexterity.rst
@@ -4,9 +4,9 @@ Creating a Dexterity project
 
 Dexterity is covered in detail in the `Dexterity Developer Manual <http://docs.plone.org/external/plone.app.dexterity/docs/>`_, which includes an extensive tutorial on setting up a Dexterity development environment and creating Dexterity add-on packages.
 
-Here, we'll just add a few details on setting up and using the ZopeSkel package creator for use with Dexterity.
+Here, we'll just add a few details on setting up and using the bobtemplates.plone package creator for use with Dexterity.
 
-The only prerequisite is a working Plone buildout and to have added mr.bob and bobtemplates.plone part described in :doc:`bootstrapping </develop/addons/bobtemplates>`.
+The only prerequisite is a working Plone buildout and to have added mr.bob and bobtemplates.plone part described in :doc:`bootstrapping </develop/addons/bobtemplates.plone/README>`.
 
 
 Create a dexterity product
@@ -46,7 +46,3 @@ Add your package to buildout
 ============================
 
 Edit your ``buildout.cfg`` file to add the package to your ``egg`` list and your ``develop`` list. Run buildout.
-
-.. note::
-
-    If you try to use a local command without this step, paster will suggest you run ``python setup.py develop``. **Do not do that.** Instead, add your package to your buildout and run buildout.

--- a/develop/addons/dexterity.rst
+++ b/develop/addons/dexterity.rst
@@ -6,39 +6,41 @@ Dexterity is covered in detail in the `Dexterity Developer Manual <http://docs.p
 
 Here, we'll just add a few details on setting up and using the ZopeSkel package creator for use with Dexterity.
 
-The only prerequisite is a working Plone buildout and to have added the ZopeSkel part described in :doc:`bootstrapping </develop/addons/paste>`.
+The only prerequisite is a working Plone buildout and to have added mr.bob and bobtemplates.plone part described in :doc:`bootstrapping </develop/addons/bobtemplates>`.
 
 
 Create a dexterity product
 ==========================
 
-Use zopeskel to create a Python package which contains a Dexterity-based product.
-(Note: just select default options - press Enter - for all questions during installation, except for project name which must be collective.example)
+Use bobtemplates.plone to create a Python package which contains a Dexterity-based product.
 
-Use ``zopeskel`` to create a Python egg which contains a Dexterity-based product.
-(Note: just select default options for all questions during installation, except for _project name_, for which we'll use ``collective.example``.)
+.. code-block::
 
-.. code-block:: console
+    mrbob -O collective.myaddon bobtemplates:plone_addon
 
-    # cd to your buildout directory
-    $ cd src
-    $ ../bin/zopeskel dexterity
-    dexterity: A Dexterity-based product
+    Welcome to mr.bob interactive mode. Before we generate directory structure, some questions need to be answered.
 
-    This template expects a project name with 1 dot in it (a 'basic
-    namespace', like 'foo.bar').
+    Answer with a question mark to display help.
+    Values in square brackets at the end of the questions show the default value if there is no answer.
 
-    Enter project name: collective.example
 
-    [...]
+    --> What kind of package would you like to create? [Basic]: Dexterity
 
-    usage: paster COMMAND
+    --> Content type name [Task]:
 
-    Commands:
-      addcontent  Adds plone content types to your project
+    --> Author's name [$NAME]:
 
-    For more information: paster help COMMAND
-    ------------------------------------------------------------------------
+    --> Author's email [$EMAIL]:
+
+    --> Author's github username:
+
+--> Package description [An add-on for Plone]:
+
+--> Plone version [4.3.4]:
+
+
+Generated file structure at $/collective.myaddon
+
 
 Add your package to buildout
 ============================
@@ -48,25 +50,3 @@ Edit your ``buildout.cfg`` file to add the package to your ``egg`` list and your
 .. note::
 
     If you try to use a local command without this step, paster will suggest you run ``python setup.py develop``. **Do not do that.** Instead, add your package to your buildout and run buildout.
-
-Add content using paster
-========================
-
-Use ``paster`` to list the types of content that can be added:
-
-.. code-block:: console
-
-        $ ../bin/paster addcontent -l
-        Available templates:
-            dexterity_behavior:  A behavior skeleton
-            dexterity_content:   A content type skeleton
-
-Add a content-type:
-
-.. code-block:: console
-
-        $ ../bin/paster addcontent dexterity_content
-        Enter contenttype_name (Content type name ) ['Example Type']: Example content
-        Enter contenttype_description (Content type description ) ['Description of the Example Type']: Just an example
-        (Use default values for rest - press Enter)
-

--- a/develop/addons/helloworld/environment/plone.rst
+++ b/develop/addons/helloworld/environment/plone.rst
@@ -10,6 +10,14 @@ Install Plone
 
 Now that we have a virtual_env, we can move on the to third step of our process; installing Plone. First, we need to install ZopeSkel.
 
+.. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
+
+
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
+
 Install ZopeSkel
 -----------------
 

--- a/develop/addons/helloworld/extend/content.rst
+++ b/develop/addons/helloworld/extend/content.rst
@@ -12,6 +12,12 @@ In this tutorial we add a custom content-type.
 
 Plone comes with built-in content-types like Collection, Event, File, Folder, Image, Link, News Item, and Page. If you need a custom content-type, you can extend an existing content-type, or create your own from scratch. In this example, we'll create a simple archetypes based content-type from scratch.
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
+
+.. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
 
 Install code template with ZopeSkel
 -------------------------------------

--- a/develop/addons/index.rst
+++ b/develop/addons/index.rst
@@ -4,7 +4,7 @@ Develop Plone Add ons
 .. toctree::
    :maxdepth: 2
 
-   bobtemplates
+   bobtemplates.plone/README
    dexterity
    paster
    releasing

--- a/develop/addons/index.rst
+++ b/develop/addons/index.rst
@@ -6,6 +6,7 @@ Develop Plone Add ons
 
    bobtemplates
    dexterity
+   paster
    releasing
    components/index
    javascript

--- a/develop/addons/index.rst
+++ b/develop/addons/index.rst
@@ -4,7 +4,7 @@ Develop Plone Add ons
 .. toctree::
    :maxdepth: 2
 
-   paste
+   bobtemplates
    dexterity
    releasing
    components/index

--- a/develop/addons/paste.rst
+++ b/develop/addons/paste.rst
@@ -3,13 +3,13 @@
 =========================================
 
 .. deprecated:: may_2015
-    Use :doc:`bobtemplates <bobtemplates>`
+    Use :doc:`bobtemplates.plone <bobtemplates.plone/README>`
 
 .. note ::
 
     Using ZopeSKel is not considered *best practice* anymore, if you know how
     to handle it and its dependencies it fine, otherwise we advise you to use
-    :doc:`bobtemplates <bobtemplates>`.
+    :doc:`bobtemplates <bobtemplates.plone/README>`.
 
 
 .. admonition:: Description

--- a/develop/addons/paste.rst
+++ b/develop/addons/paste.rst
@@ -2,6 +2,13 @@
  Bootstrapping Plone add-on development
 =========================================
 
+.. note ::
+
+    Using ZopeSKel is not considered *best practice* anymore, if you know how
+    to handle it and its dependencies it fine, otherwise we advise you to use
+    :doc:`bobtemplates <bobtemplates>`.
+
+
 .. admonition:: Description
 
     ZopeSkel is a tool which generates a code skeleton template for your

--- a/develop/addons/paste.rst
+++ b/develop/addons/paste.rst
@@ -2,6 +2,9 @@
  Bootstrapping Plone add-on development
 =========================================
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates <bobtemplates>`
+
 .. note ::
 
     Using ZopeSKel is not considered *best practice* anymore, if you know how

--- a/develop/addons/schema-driven-forms/creating-a-simple-form/creating-a-package.rst
+++ b/develop/addons/schema-driven-forms/creating-a-simple-form/creating-a-package.rst
@@ -9,7 +9,15 @@ requires a form, you should be able to add the same dependencies. If you
 have read the :doc:`Dexterity developer manual </external/plone.app.dexterity/docs/index>`, most of this should be familiar.
 
 For details about creating new packages, see
-:doc:`Bootstrapping Plone add-on development </develop/addons/paste>`.
+:doc:`Bootstrapping Plone add-on development </develop/addons/bobtemplates.plone/README>`.
+
+.. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
+
+
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
 
 First, we create a new package:
 

--- a/develop/plone/content/types.rst
+++ b/develop/plone/content/types.rst
@@ -80,7 +80,7 @@ Python instead, here's how::
         # Return (id, title) pairs
         return [ (id, portal_types[id].title) for id in prepared_types ]
 
-. note:: 
+.. note:: 
 
     Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
 

--- a/develop/plone/content/types.rst
+++ b/develop/plone/content/types.rst
@@ -80,6 +80,9 @@ Python instead, here's how::
         # Return (id, title) pairs
         return [ (id, portal_types[id].title) for id in prepared_types ]
 
+. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
 
 Creating a new content type
 ============================
@@ -104,6 +107,7 @@ Add ZopeSkel to your buildout.cfg and run buildout::
     eggs =
        PasteScript
        ZopeSkel
+
 
 Create an archetypes product
 ----------------------------
@@ -139,11 +143,15 @@ Adjust your buildout.cfg and run buildout again::
 Create a new content type
 -------------------------
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
+
 Change into the directory of the new product and then use paster to
 add a new content type::
 
     cd my.product
     ../bin/paster addcontent contenttype
+
 
 
 Related how-tos:

--- a/develop/plone/forms/z3c.form.rst
+++ b/develop/plone/forms/z3c.form.rst
@@ -112,6 +112,9 @@ Here is a minimal form implementation using ``z3c.form`` and Dexterity:
 
 * Create Plone add-on product using :doc:`Paster </develop/addons/paste>`
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
+
 * Include :doc:`five.grok support in your add-on </appendices/grok>`
 
 * Toss ``form.py`` into your add-on product::

--- a/develop/plone/functionality/portlets.rst
+++ b/develop/plone/functionality/portlets.rst
@@ -35,6 +35,10 @@ for ready solution, for examples, for inspiration.
 
 * https://github.com/collective/collective.cover
 
+.. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
+
 Creating a portlet
 ------------------
 
@@ -43,6 +47,9 @@ Creating a portlet
 
 * Use project specific paster command *paster addcontent portlet* to create a code
   skeleton for your new portlet.
+
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
 
 Subclassing a portlet
 ---------------------

--- a/develop/plone/misc/paster_templates.rst
+++ b/develop/plone/misc/paster_templates.rst
@@ -2,6 +2,12 @@
  Creating your own Paster templates
 ======================================================
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
+
+.. note::
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
+
 .. admonition:: Description
 
 	How to create Paster code skeleton templates to easily add your

--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -56,6 +56,14 @@ please read the `Plone and Grok tutorial
 .. note:: At the time of writing (Q1/2010), all project templates in Paster
    still use old-style Zope views.
 
+.. deprecated:: may_2015
+    Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>` instead
+
+.. note:: 
+
+    Using paster is deprecated instead you should use :doc:`bobtemplates.plone
+    </develop/addons/bobtemplates.plone/README>`
+
 More information
 ----------------
 
@@ -120,7 +128,7 @@ Views rendering page snippets and parts can be subclasses of zope.publisher.brow
 as snippets might not need acquisition support which adds some overhead to the rendering process.
 
 Customizing views
-===========================
+=================
 
 To customize existing Plone core or add-on views you have different options.
 
@@ -131,13 +139,13 @@ To customize existing Plone core or add-on views you have different options.
   installs a view class replacement using add-on layer.
 
 Overriding view template
---------------------------
+------------------------
 
 Follow instructions how to :doc:`use z3c.jbot
 </adapt-and-extend/theming/templates_css/template_basics>` to override templates.
 
 Overriding view class
-------------------------
+---------------------
 
 Here is a short introduction on finding how existing views are defined.
 
@@ -176,19 +184,19 @@ Creating and registering a view
 This shows how to create and register view in a Zope 3 manner.
 
 Creating a view using Grok
-------------------------------
+--------------------------
 
 This is the simplest method and recommended for Plone 4.1+ onwards.
 
 First, create your add-on product using
-:doc:`Dexterity project template </develop/addons/paste>`. The most important
+:doc:`Dexterity project template </develop/addons/bobtemplates.plone/README>`. The most important
 thing in the add-on is that your registers itself to :doc:`grok </appendices/grok>`
 which allows Plone to scan all Python files for ``grok()`` directives and
 furter automatically pick up your views (as opposite using old Zope 3 method
 where you manually register views by typing them in to ZCML in ZCML).
 
 configure.zcml
-`````````````````````
+``````````````
 
 First make sure the file ``configure.zcml`` in your add-on root folder
 contains the following lines. These lines are needed only once, in the root
@@ -220,7 +228,7 @@ or have :doc:`five.grok in your setup.py </appendices/grok>`. If you didn't add 
 point and run buildout again to download and install ``five.grok`` package.
 
 Python logic code
-`````````````````````
+`````````````````
 
 Add the file ``yourcompany.app/yourcompany/app/browser/views.py``::
 
@@ -274,7 +282,7 @@ docs to make the view available only for certain content types. Example
 	grok.context(IATDocument)
 
 Page template
-`````````````````````
+`````````````
 
 Then create a :doc:`page template for your view. </adapt-and-extend/theming/templates_css/template_basics>`.
 Create ``yourcompany.app/yourcompany/app/browser/templates`` and add
@@ -300,7 +308,7 @@ grok will scan all Python files for available files, so it doesn't matter
 what .py filename you use.
 
 Content slots
-------------------
+-------------
 
 Available :doc:`slot </adapt-and-extend/theming/templates_css/template_basics>`
 options you can use for ``<metal fill-slot="">`` in your template which
@@ -324,7 +332,7 @@ inherits from ``<html metal:use-macro="context/main_template/macros/master">``:
     main template.
 
 Accessing your newly created view
------------------------------------
+---------------------------------
 
 Now you can access your view within the news folder::
 
@@ -349,7 +357,7 @@ More info
 
 
 Setting view permissions
-``````````````````````````
+````````````````````````
 
 Use `grok.require <http://grok.zope.org/doc/current/reference/directives.html#grok-require>`_
 
@@ -369,7 +377,7 @@ More info:
 * https://plone.org/products/dexterity/documentation/manual/five.grok/browser-components/views
 
 Creating a view using ZCML
-------------------------------
+--------------------------
 
 Example::
 
@@ -412,7 +420,7 @@ Example::
     method which ``__call__()`` or view users can explicitly call.
 
 Registering a view
-`````````````````````
+``````````````````
 
 Zope 3 views are registered in :term:`ZCML`, an XML-based configuration
 language.  Usually, the configuration file, where the registration done, is
@@ -466,7 +474,7 @@ The following example registers a new view (see below for comments):
    ``configure.zcml`` to use ``browser`` configuration directives.
 
 Relationship between views and templates
-``````````````````````````````````````````
+````````````````````````````````````````
 
 The ZCML ``<browser:view template="">`` directive will set the ``index``
 class attribute.
@@ -525,7 +533,7 @@ Rendering of the view is done as follows::
             return self.render()
 
 Overriding a view template at run-time
-````````````````````````````````````````
+``````````````````````````````````````
 
 Below is a sample code snippet which allows you to override an already
 constructed ``ViewPageTemplateFile`` with a chosen file at run-time::


### PR DESCRIPTION
This updates the docs to say bobtemplates.plone is the new way instead of paster/zeopskel.

- update links
- add notes about bobtemplates.plone
- add deprecation messages with links to bobtemplates.plone

Please review this, since I changed a lot of files, maybe something slipped through  