### PR TITLE
including non-requirejs scripts with plone

### DIFF
--- a/adapt-and-extend/theming/resources.rst
+++ b/adapt-and-extend/theming/resources.rst
@@ -473,7 +473,7 @@ should allow your scripts to run normally.
 Example::
 
       <!-- Plone bundles here -->
-      <script type="text/javascript">
+      <script>
         require = undefined
         define = undefined
       </script>
@@ -487,7 +487,7 @@ Example::
 
       <before theme="/html/head/script[1]">
           <xsl:apply-templates select="/html/head/script" />
-          <script type="text/javascript">
+          <script>
               require = undefined
               define = undefined
           </script>

--- a/adapt-and-extend/theming/resources.rst
+++ b/adapt-and-extend/theming/resources.rst
@@ -460,3 +460,35 @@ This is how requirejs works and is normal behavior; however, any novice will lik
 come around to noticing this when working with AMD JavaScript. With Plone,
 it's one additional caveat you'll need to be aware of when working with the Resource
 Registry.
+
+Including non-requirejs scripts with Plone
+------------------------------------------
+
+If you have scripts that cannot be updated to use requirejs, it may be possible
+to include both.
+
+After the Plone scripts, you can unset the require and define variables which
+should allow your scripts to run normally.
+
+Example::
+
+      <!-- Plone bundles here -->
+      <script type="text/javascript">
+        require = undefined
+        define = undefined
+      </script>
+      <script>
+        // Your javascript here
+      </script>
+
+You can add the Plone resources to your theme before your own javascript.
+
+Example::
+
+      <before theme="/html/head/script[1]">
+          <xsl:apply-templates select="/html/head/script" />
+          <script type="text/javascript">
+              require = undefined
+              define = undefined
+          </script>
+      </before>


### PR DESCRIPTION
This is some notes on adding non requirejs javascript to a theme whilst also including the plone bundles.

Raised by https://github.com/plone/Products.CMFPlone/issues/984
