### PR TITLE
Add basic docs for frontend/backend theming

### DIFF
--- a/adapt-and-extend/theming/resources.rst
+++ b/adapt-and-extend/theming/resources.rst
@@ -371,19 +371,23 @@ Example::
         <xi:include href="++theme++barceloneta/backend.xml" />
 
         <!-- Only theme front end pages -->
-        <rules css:if-content="body.viewpermission-view,body.viewpermission-none">
+        <rules css:if-content="body.frontend" css:if-content="#visual-portal-wrapper">
 
-            <rules css:if-content="#visual-portal-wrapper">
+            <theme href="index.html" />
 
-                <theme href="index.html" />
+            <!-- Include basic plone/toolbar bundles -->
+            <after theme-children="/html/head" content="/html/head/link[@data-bundle='basic' or @data-bundle='plone' or @data-bundle='plone-logged-in' or @data-bundle='diazo']" />
+            <after theme-children="/html/head" content="/html/head/script[@data-bundle='basic' or @data-bundle='plone' or @data-bundle='plone-logged-in' or @data-bundle='diazo']" />
 
-                <!-- Your diazo front end rules go here -->
+            <!-- Insert the toolbar -->
+            <before css:theme-children="body" css:content-children="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />
 
-            </rules>
+            <!-- Your diazo front end rules go here -->
+
         </rules>
     </rules>
 
-TODO - including the toolbar in the front-end
+You can define your own diazo bundle in your manifest.cfg (by using development-js, production-js and css options). This diazo bundle will not be included in the backend theme.
 
 
 Browser Page bundle

--- a/adapt-and-extend/theming/resources.rst
+++ b/adapt-and-extend/theming/resources.rst
@@ -371,13 +371,13 @@ Example::
         <xi:include href="++theme++barceloneta/backend.xml" />
 
         <!-- Only theme front end pages -->
-        <rules css:if-content="body.frontend" css:if-content="#visual-portal-wrapper">
+        <rules css:if-content="body.frontend#visual-portal-wrapper">
 
             <theme href="index.html" />
 
             <!-- Include basic plone/toolbar bundles -->
-            <after theme-children="/html/head" content="/html/head/link[@data-bundle='basic' or @data-bundle='plone' or @data-bundle='plone-logged-in' or @data-bundle='diazo']" />
-            <after theme-children="/html/head" content="/html/head/script[@data-bundle='basic' or @data-bundle='plone' or @data-bundle='plone-logged-in' or @data-bundle='diazo']" />
+            <after css:theme-children="head" css:content="head link[data-bundle='basic'], head link[data-bundle='plone'], head link[data-bundle='plone-logged-in'], head link[data-bundle='diazo']" />
+            <after css:theme-children="head" css:content="head script[data-bundle='basic'], head script[data-bundle='plone'], head script[data-bundle='plone-logged-in'], script link[data-bundle='diazo']" />
 
             <!-- Insert the toolbar -->
             <before css:theme-children="body" css:content-children="#edit-bar" css:if-not-content=".ajax_load" css:if-content=".userrole-authenticated" />

--- a/adapt-and-extend/theming/resources.rst
+++ b/adapt-and-extend/theming/resources.rst
@@ -356,9 +356,34 @@ The options are :
 Diazo frontend - barceloneta backend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Using diazo rules you can define a frontend and a backend separatelly defining which bundles you want to load.
+Using diazo rules you can theme the frontend of your site how you like, and use the default Barceloneta theme for the backend.
 
-TODO
+Example::
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rules
+        xmlns="http://namespaces.plone.org/diazo"
+        xmlns:css="http://namespaces.plone.org/diazo/css"
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:xi="http://www.w3.org/2001/XInclude">
+
+        <!-- Include the backend theme -->
+        <xi:include href="++theme++barceloneta/backend.xml" />
+
+        <!-- Only theme front end pages -->
+        <rules css:if-content="body.viewpermission-view,body.viewpermission-none">
+
+            <rules css:if-content="#visual-portal-wrapper">
+
+                <theme href="index.html" />
+
+                <!-- Your diazo front end rules go here -->
+
+            </rules>
+        </rules>
+    </rules>
+
+TODO - including the toolbar in the front-end
 
 
 Browser Page bundle


### PR DESCRIPTION
Some very rudimentary documentation on using the backend version of Barceloneta in a theme.

Original issue https://github.com/plone/Products.CMFPlone/issues/465
Relevant pull request https://github.com/plone/plonetheme.barceloneta/pull/40
