### PR TITLE
Never ever tell ppl to do dist-upgrade for install

### DIFF
--- a/manage/deploying/production/ubuntu_production.rst
+++ b/manage/deploying/production/ubuntu_production.rst
@@ -38,7 +38,7 @@ First step with any new server is to update the already installed system librari
 .. code-block:: console
 
     sudo apt-get update
-    sudo apt-get dist-upgrade
+    sudo apt-get upgrade
 
 Then, install the platform's build kit, nginx, and supervisor:
 


### PR DESCRIPTION
- Fix for #387 Plone 5
  Never ever tell ppl that they have to do dist-upgrade ! 'apt-get upgrade' or with apt2 'apt upgrade' is enough.
