### PR TITLE
Apache load balancing: use pending request counting algorithm

### DIFF
--- a/manage/deploying/front-end/apache.rst
+++ b/manage/deploying/front-end/apache.rst
@@ -329,7 +329,7 @@ More information about how to set a sticky session cookie if you need to support
 
 Example::
 
-        <VirtualHost 123.123.123:443>
+        <VirtualHost 123.123.123.123:443>
 
           ServerName  production.yourorganization.org
           ServerAdmin rocks@mfabrik.com
@@ -352,11 +352,16 @@ Example::
           </IfModule>
 
           # Balance load between 4 ZEO front-ends
+          # Use Pending Request Counting Algorithm (s. http://httpd.apache.org/docs/current/mod/mod_lbmethod_bybusyness.html).
+          # It is much better at reducing latencies that occur as a result
+          # of single long running requests blocking a ZEO client than Apache's default.
+          # You will need to install the separate mod_lbmethod_bybusyness module in Apache 2.4.
           <Proxy balancer://lbyourorganization>
             BalancerMember http://127.0.0.1:13001/
             BalancerMember http://127.0.0.1:13002/
             BalancerMember http://127.0.0.1:13003/
             BalancerMember http://127.0.0.1:13004/
+            ProxySet lbmethod=bybusyness
           </Proxy>
 
           # Note: You might want to disable this URL of being public
@@ -374,10 +379,10 @@ Example::
 
           # Disk cache configuration, if you really must use Apache for caching
           CacheEnable disk /
-	  # Must point to www-data writable directly which depends on OS
+          # Must point to www-data writable directly which depends on OS
           CacheRoot "/var/cache/yourorganization-production"
           CacheLastModifiedFactor 0.1
-          CacheIgnoreHeader Set-Cookie
+          CacheIgnoreHeaders Set-Cookie
 
           # Debug header flags all requests coming from this server
           Header append X-YourOrganization-Production yes

--- a/manage/deploying/front-end/apache.rst
+++ b/manage/deploying/front-end/apache.rst
@@ -352,15 +352,14 @@ Example::
           </IfModule>
 
           # Balance load between 4 ZEO front-ends
-          # Use Pending Request Counting Algorithm (s. http://httpd.apache.org/docs/current/mod/mod_lbmethod_bybusyness.html).
-          # It is much better at reducing latencies that occur as a result
-          # of single long running requests blocking a ZEO client than Apache's default.
-          # You will need to install the separate mod_lbmethod_bybusyness module in Apache 2.4.
           <Proxy balancer://lbyourorganization>
             BalancerMember http://127.0.0.1:13001/
             BalancerMember http://127.0.0.1:13002/
             BalancerMember http://127.0.0.1:13003/
             BalancerMember http://127.0.0.1:13004/
+            # Use Pending Request Counting Algorithm (s. http://httpd.apache.org/docs/current/mod/mod_lbmethod_bybusyness.html).
+            # This will reduce latencies that occur as a result of long running requests temporarily blocking a ZEO client.
+            # You will need to install the separate mod_lbmethod_bybusyness module in Apache 2.4.
             ProxySet lbmethod=bybusyness
           </Proxy>
 


### PR DESCRIPTION
I'd like to suggest a small change for the Apache Load Balancing section:
Using pending request counting instead of Apache's default request counting works well with Plone and will result in a better overall performance of a site. This PR also fixes some small typos/whitespace.
