### PR TITLE
Do not use direct assignment to attribute in order to set default page

### DIFF
--- a/develop/plone/content/dynamic_views.rst
+++ b/develop/plone/content/dynamic_views.rst
@@ -257,10 +257,10 @@ Another example how to use this::
 
 .. TODO:: Bare except?
 
-Setting the default page can be done as simply as setting a ``default_page``
-attribute on the folder to the id of the default page::
+Setting the default page can be done by calling the ``setDefaultPage`` on the folder, passing id of the default 
+page::
 
-    folder.default_page = "my_content_id"
+    folder.setDefaultPage("my_content_id")
 
 More information can be found in
 


### PR DESCRIPTION
Assigning directly to the default_page attribute works, but it can mess with the property manager (getProperty, setProperty, etc) and then you'll be unable to change the default view using the Plone UI.
