### PR TITLE
gzip was removed from plone.app.caching

### DIFF
--- a/manage/deploying/front-end/apache.rst
+++ b/manage/deploying/front-end/apache.rst
@@ -388,5 +388,14 @@ Example::
 
         </VirtualHost>
 
+Enabling gzip compression
+-------------------------
+
+Enabling gzip compression in Apache will make your web sites respond much more quickly for your web site users and will reduce the amount of bandwidth used by your web sites.
+
+Instructions for enabling gzip in Apache: 
+
+* https://varvy.com/pagespeed/enable-compression.html
+* http://httpd.apache.org/docs/2.2/mod/mod_deflate.html
 
 

--- a/manage/deploying/front-end/nginx.rst
+++ b/manage/deploying/front-end/nginx.rst
@@ -611,5 +611,5 @@ Enabling gzip compression in Nginx will make your web sites respond much more qu
 
 Instructions for enabling gzip in Nginx: 
 
+* https://varvy.com/pagespeed/enable-compression.html
 * https://www.nginx.com/resources/admin-guide/compression-and-decompression/
-* http://httpd.apache.org/docs/2.2/mod/mod_deflate.html

--- a/manage/deploying/front-end/nginx.rst
+++ b/manage/deploying/front-end/nginx.rst
@@ -603,3 +603,13 @@ Limitations:
 * Nginx does not support the s-maxage cache-control directive. Only max-age.
   This means that moderate caching will do nothing. However, strong caching works and will cause all your static resources and registry items to be cached.
   Don't underestimate how valuable that is.
+
+Enabling gzip compression
+-------------------------
+
+Enabling gzip compression in Nginx will make your web sites respond much more quickly for your web site users and will reduce the amount of bandwidth used by your web sites.
+
+Instructions for enabling gzip in Nginx: 
+
+* https://www.nginx.com/resources/admin-guide/compression-and-decompression/
+* http://httpd.apache.org/docs/2.2/mod/mod_deflate.html

--- a/manage/deploying/front-end/nginx.rst
+++ b/manage/deploying/front-end/nginx.rst
@@ -605,7 +605,7 @@ Limitations:
   Don't underestimate how valuable that is.
 
 Enabling gzip compression
--------------------------
+=========================
 
 Enabling gzip compression in Nginx will make your web sites respond much more quickly for your web site users and will reduce the amount of bandwidth used by your web sites.
 

--- a/manage/deploying/stack.rst
+++ b/manage/deploying/stack.rst
@@ -176,12 +176,6 @@ Set a basic profile by making a choice from this menu. Then use ``Change setting
 Enable caching
     Turn this on, and you'll get some immediate improvement in cache efficacy -- including browser caches. Tune it up for your particular needs with the other panes in this configuration panel.
 
-Enable GZip compression
-    GZip compression is one of those rare total wins. Turning it on will cause Plone to compress most text resources before transmitting them.
-    All modern browsers know how to uncompress them. You'll save bandwidth and speed up your effective page delivery for a tiny hit on CPU load.
-
-    Why wouldn't you turn on Gzip compression? The best reason is because you may wish to instead handle this via your web server (nginx/Apache) or reverse proxy. Threading issues tend to be much better handled by a good proxy than by Zope/Plone. Also, the same gzip settings can handle Zope/Plone and other web apps.
-
 **Caching Proxies**
 
 Think of this as the Varnish/Squid settings page, as it's mainly concerned with cache purging, which is typically not supported by web server proxy caches.


### PR DESCRIPTION
moving gzip info to apache and nginx docs sections instead
