### PR TITLE
Remove RPM - docs are based on Ubuntu

### DIFF
--- a/manage/deploying/caching/varnish3.rst
+++ b/manage/deploying/caching/varnish3.rst
@@ -24,6 +24,7 @@ To use Varnish with Plone
 
 * Add Plone virtual hosting rule to the default varnish configuration
 
+
 .. note ::
 
     Some of these examples were written for Varnish 2.x.
@@ -34,7 +35,7 @@ Installation
 
 The suggest method to install Varnish is to use your OS package manager.
 
-* You can install using packages (RPM/DEB) - consult your operating system instructions.
+* You can install using packages (DEB) - consult your operating system instructions.
 
 * For more up to date packages for Debian you could check: https://www.varnish-cache.org/installation/debian
 

--- a/manage/deploying/caching/varnish4.rst
+++ b/manage/deploying/caching/varnish4.rst
@@ -39,8 +39,6 @@ The suggest method to install Varnish is to use your OS package manager.
 
 * For more up to date packages for Debian you could check: https://www.varnish-cache.org/installation/debian
 
-* For more up to date packages for RedHat (RPM Based) you could check: https://www.varnish-cache.org/installation/redhat
-
 * You can install backports
 
 * You can install using buildout
@@ -53,7 +51,7 @@ Management console
 ==================
 
 ``varnishadm``
---------------------------------------------
+--------------
 
 You can access Varnish admin console on your server by::
 

--- a/manage/deploying/caching/varnish4.rst
+++ b/manage/deploying/caching/varnish4.rst
@@ -35,7 +35,7 @@ Installation
 
 The suggest method to install Varnish is to use your OS package manager.
 
-* You can install using packages (RPM/DEB) - consult your operating system instructions.
+* You can install using packages (DEB) - consult your operating system instructions.
 
 * For more up to date packages for Debian you could check: https://www.varnish-cache.org/installation/debian
 


### PR DESCRIPTION
- Remove RPM, docs are base on Ubuntu, we do not want to confuse user
