### PR TITLE
removed "Short Name" info

### DIFF
--- a/adapt-and-extend/config/editing.rst
+++ b/adapt-and-extend/config/editing.rst
@@ -19,15 +19,6 @@ Editing
    :align: center
    :alt: Editing setup configuration
 
-
-You can allow users to edit the "Short name" of content items.
-
-.. note::
-
-    The "Short Name" is part of the URL of a content item.
-    That means that no special characters or spaces are allowed in it.
-    For experienced web editors, it can be handy to manipulate the Short Name directly in order to generate more memorable or shorter URL's.
-
 "Link Integrity Checks" means that users will be warned if they try to delete an item that is being linked to from another content item.
 This setting is usually best left "on"
 


### PR DESCRIPTION
"Short Name" is no longer available on this screen in Plone 5.
