### PR TITLE
Remove redundancy

### DIFF
--- a/develop/index.rst
+++ b/develop/index.rst
@@ -2,25 +2,15 @@ Developing for Plone
 ====================
 
 
-Developing add-ons
-------------------
-
 .. toctree::
    :maxdepth: 2
 
    addons/index
 
-Programming with Plone
-----------------------
-
 .. toctree::
    :maxdepth: 2
 
    plone/index
-
-
-Debugging Plone
----------------
 
 .. toctree::
    :maxdepth: 2
@@ -28,17 +18,11 @@ Debugging Plone
    debugging/index
 
 
-Testing Plone
--------------
-
 .. toctree::
    :maxdepth: 2
 
    testing/index
 
-
-Developing for Plone Core
--------------------------
 
 .. toctree::
    :maxdepth: 4


### PR DESCRIPTION
Currently when going to http://docs.plone.org/develop/index.html the left column looks like this:

![toc](https://cloud.githubusercontent.com/assets/1155680/12076264/1c741554-b1a4-11e5-8f57-1671286369f4.png)

There's quite a lot of duplication, I'm not sure where to cut it from to make it more meaningful, either on the subfolder titles or on the parent index.

I thought that it make more sense to remove it on the parent so that subfolders are a complete unit without need of external information.

Not sure how does it look like once the titles are removed thought.

This is mostly WIP and open to discussion.

Happy new year!
