### PR TITLE
Update styleguide regarding sorting imports

### DIFF
--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -311,7 +311,7 @@ Grouping and sorting
 
 Since Plone has such a huge code base,
 we don't want to lose developer time figuring out into which group some import goes (standard lib?, external package?, etc.).
-So we just sort everything alphabetically and insert one blank line between ``from foo import bar`` and ``import baz`` blocks. Conditional imports come last. Again, we *do not* distinguish between what is standard lib,
+So we just sort everything alphabetically case insensitive and insert one blank line between ``from foo import bar`` and ``import baz`` blocks. Conditional imports come last. Again, we *do not* distinguish between what is standard lib,
 external package or internal package in order to save time and avoid the hassle of explaining which is which.
 
 .. sourcecode:: python

--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -348,6 +348,7 @@ Add the following::
 
 To either ``.isort.cfg`` or changing the header from ``[settings]`` to ``[isort]`` and putting it on ``setup.cfg``.
 
+You can also use `plone.recipe.codeanalysis <http://pypi.python.org/pypi/plone.recipe.codeanalysis>`_ with the `flake8-isort <https://pypi.python.org/pypi/flake8-isort>`_ plugin enabled to check for it.
 
 Declaring dependencies
 ======================

--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -334,6 +334,20 @@ external package or internal package in order to save time and avoid the hassle 
     else:
         HAS_DEXTERITY = True
 
+`isort <http://pypi.python.org/pypi/isort>`_,
+a python tool to sort imports can be configured to sort exactly as described above.
+
+Add the following::
+
+    [settings]
+    force_alphabetical_sort=True
+    force_single_line=True
+    lines_after_imports=2
+    line_length=200
+    not_skip=__init__.py
+
+To either ``.isort.cfg`` or changing the header from ``[settings]`` to ``[isort]`` and putting it on ``setup.cfg``.
+
 
 Declaring dependencies
 ======================

--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -309,13 +309,10 @@ About imports
 Grouping and sorting
 --------------------
 
-Since Plone has such a huge code base, we don't want to lose developer time
-figuring out into which group some import goes (standard lib?, external
-package?, etc.). So we just sort everything alphabetically and insert one blank
-line between ``from foo import bar`` and ``import baz`` blocks. Conditional imports
-come last. Again, we *do not* distinguish between what is standard lib,
-external package or internal package in order to save time and avoid the hassle
-of explaining which is which.
+Since Plone has such a huge code base,
+we don't want to lose developer time figuring out into which group some import goes (standard lib?, external package?, etc.).
+So we just sort everything alphabetically and insert one blank line between ``from foo import bar`` and ``import baz`` blocks. Conditional imports come last. Again, we *do not* distinguish between what is standard lib,
+external package or internal package in order to save time and avoid the hassle of explaining which is which.
 
 .. sourcecode:: python
 


### PR DESCRIPTION
Follow up of #500  (nice number one @do3cc ) and https://github.com/plone/plone.api/issues/187.

At [Alpine City Sprint](http://www.coactivate.org/projects/alpinecitysprint-2016/project-home) @jensens @do3cc and me discussed about the issue and end up deciding that tooling is more important than editors and thus, we follow suit what [isort](http://pypi.python.org/pypi/isort) provides us, i.e. alphabetically case-insensitive sorting and one line between `from X import Y` and `import Z`.

My personal opinion to whoever wants to change it: update [isort](https://github.com/timothycrosley/isort) so that it sorts how you like and **only after that** we can open, yet again, the discussion.

As a matter of fact, currently our stack compromises +8500 python files, who is gonna update them manually without a tool to do so and keep them checked?
