### PR TITLE
statement about multi-line import

### DIFF
--- a/develop/styleguide/editor.rst
+++ b/develop/styleguide/editor.rst
@@ -2,11 +2,9 @@ How to set up your editor
 =========================
 
 
-`EditorConfig <http://editorconfig.org/>`_
-provides a way to share the same configuration for all major source code editors.
+`EditorConfig <http://editorconfig.org/>`_ provides a way to share the same configuration for all major source code editors.
 
-You only need to install the plugin for your editor of choice,
-and add the following configuration on ``~/.editorconfig``.
+You only need to install the plugin for your editor of choice, and add the following configuration on ``~/.editorconfig``.
 
 .. code-block:: ini
 

--- a/develop/styleguide/javascript.rst
+++ b/develop/styleguide/javascript.rst
@@ -1,12 +1,10 @@
 JavaScript styleguide
 =====================
 
-*NOTE: Plone doesn't yet use any of the new
-`ES2015 <https://babeljs.io/docs/learn-es2015/>`__ features.*
+*NOTE: Plone doesn't yet use any of the new `ES2015 <https://babeljs.io/docs/learn-es2015/>`__ features.*
 
-Many of the style guide recommendations here come from Douglas
-Crockford's seminal book `Javascript, the good
-parts <http://shop.oreilly.com/product/9780596517748.do>`__.
+Many of the style guide recommendations here come from Douglas Crockford's seminal book `Javascript, the good parts <http://shop.oreilly.com/product/9780596517748.do>`__.
+
 
 Indentation
 -----------
@@ -14,10 +12,10 @@ Indentation
 Indentation is an important aid for readability and comprehension.
 When editing a file, please keep to the convention already established.
 
-In `Patternslib <http://patternslib.com>`_ we indent 4 spaces as suggested by
-Douglas Crockford in *Javascript, the good parts*.
+In `Patternslib <http://patternslib.com>`_ we indent 4 spaces as suggested by Douglas Crockford in *Javascript, the good parts*.
 
 The `Mockup <https://github.com/plone/mockup>` patterns on the other hand indent 2 spaces.
+
 
 Naming of variables, classes and functions
 ------------------------------------------
@@ -36,6 +34,7 @@ For example:
         ...
     }
 
+
 jQuery objects are prefixed with $
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -47,6 +46,7 @@ For example:
 
     var divs = document.getElementsByTagName('div'); // List of DOM elements
     var $divs = $('div'); // jQuery object
+
 
 Spaces around operators
 -----------------------
@@ -69,14 +69,13 @@ An exception is when they appear inside for-loop expressions, for example:
         // do something
     }
 
-Generally though, rather err on the side of adding spaces, since they
-make the code much more readable.
+Generally though, rather err on the side of adding spaces, since they make the code much more readable.
+
 
 Constants are written in ALL\_CAPS
 ----------------------------------
 
-Identifiers that denote constant values should be written in all capital
-letters, with underscores between words.
+Identifiers that denote constant values should be written in all capital letters, with underscores between words.
 
 For example:
 
@@ -85,13 +84,11 @@ For example:
     var SECONDS_IN_HOUR = 3600; // constant
     var seconds_since_click = 0; // variable
 
+
 Function declaration and invocation
 -----------------------------------
 
-In his book, *Javascript, the good parts*, Douglas Crockford suggests
-that function names and the brackets that come afterwards should be
-separated with a space, to indicate that it's a declaration and not a
-function call or instantiation.
+In his book, *Javascript, the good parts*, Douglas Crockford suggests that function names and the brackets that come afterwards should be separated with a space, to indicate that it's a declaration and not a function call or instantiation.
 
 ::
 
@@ -101,22 +98,23 @@ function call or instantiation.
 
     update(model); // function call
 
-This practice however doesn't appear to be very common and is also not
-used consistently throughout the codebase. It might however be
-useful sometimes, to reduce confusion.
+This practice however doesn't appear to be very common and is also not used consistently throughout the codebase.
+It might however be useful sometimes, to reduce confusion.
+
 
 Checking for equality
 ---------------------
 
-Javascript has a strict ``===`` and less strict ``==`` equality
-operator. The stricter operator also does type checking. To avoid subtle
-bugs when doing comparisons, always use the strict equality check.
+Javascript has a strict ``===`` and less strict ``==`` equality operator.
+The stricter operator also does type checking.
+To avoid subtle bugs when doing comparisons, always use the strict equality check.
+
 
 Curly brackets
 --------------
 
-Curly brackets must appear on the same lines as the ``if`` and ``else``
-keywords. The closing curly bracket appears on its own line.
+Curly brackets must appear on the same lines as the ``if`` and ``else`` keywords.
+The closing curly bracket appears on its own line.
 
 For example:
 
@@ -131,13 +129,12 @@ For example:
         }
     }
 
+
 Always enclose blocks in curly brackets
 ---------------------------------------
 
-When writing an a block such as an ``if`` or ``while`` statement, always
-use curly brackets around that block of code. Even when not strictly
-required by the compiler (for example if its only one line inside the
-``if`` statement).
+When writing an a block such as an ``if`` or ``while`` statement, always use curly brackets around that block of code.
+Even when not strictly required by the compiler (for example if its only one line inside the ``if`` statement).
 
 For example, like this:
 
@@ -156,19 +153,16 @@ and **NOT** like this:
         this.updateRoomsList();
     somethingElse();
 
-This is to aid in readability and to avoid subtle bugs where certain
-lines are wrongly assumed to be executed within a block.
+This is to aid in readability and to avoid subtle bugs where certain lines are wrongly assumed to be executed within a block.
+
 
 Binding the "this" variable versus assigning to "self"
 ------------------------------------------------------
 
-One of the deficiencies in JavaScript is that callback functions are not
-bound to the correct or expected context (as referenced with the ``this`` variable). In
-`ES2015 <https://babeljs.io/docs/learn-es2015/>`__, this problem is
-solved by using so-called arrow functions for callbacks.
+One of the deficiencies in JavaScript is that callback functions are not bound to the correct or expected context (as referenced with the ``this`` variable).
+In `ES2015 <https://babeljs.io/docs/learn-es2015/>`__, this problem is solved by using so-called arrow functions for callbacks.
 
-However, while we're still writing ES5 code, we can use the ``.bind``
-method to bind the correct ``this`` context to the callback method.
+However, while we're still writing ES5 code, we can use the ``.bind`` method to bind the correct ``this`` context to the callback method.
 
 For example:
 
@@ -180,11 +174,11 @@ For example:
         this.$el.hide();
     }.bind(this), 1000);
 
+
 What about assigning the outer "this" to "self"?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A different way of solving the above problem is to assign the outer
-``this`` variable to ``self`` and then using ``self`` in the callback.
+A different way of solving the above problem is to assign the outer ``this`` variable to ``self`` and then using ``self`` in the callback.
 
 For example:
 
@@ -198,16 +192,12 @@ For example:
 
 This practice is commonly used in the Mockup patterns.
 
-It is however discouraged in Patternslib because it results
-in much longer functions due to the fact that callback functions can't
-be moved out of the containing function where ``self`` is defined.
+It is however discouraged in Patternslib because it results in much longer functions due to the fact that callback functions can't be moved out of the containing function where ``self`` is defined.
 
-Additionally, ``self`` is by default an alias for ``window``. If you
-forget to use ``var self``, there's the potential for bugs that can be
-difficult to track down.
+Additionally, ``self`` is by default an alias for ``window``.
+If you forget to use ``var self``, there's the potential for bugs that can be difficult to track down.
 
-Douglas Crockford and others suggest that the variable ``that`` be used
-instead, which is also the convention we follow in Patternslib.
+Douglas Crockford and others suggest that the variable ``that`` be used instead, which is also the convention we follow in Patternslib.
 
 For example:
 
@@ -218,6 +208,7 @@ For example:
     setTimeout(function () {
         that.$el.hide();
     }, 1000);
+
 
 Use named functions
 -------------------
@@ -232,9 +223,9 @@ JavaScript has both named functions and unnamed functions.
     // This is an unnamed function
     var foo = function() { };
 
-Unnamed functions are convenient, but result in unreadable call stacks
-and profiles. This makes debugging and profiling code unnecessarily
-hard. To fix this always use named functions for non-trivial functions.
+Unnamed functions are convenient, but result in unreadable call stacks and profiles.
+This makes debugging and profiling code unnecessarily hard.
+To fix this always use named functions for non-trivial functions.
 
 ::
 
@@ -242,12 +233,9 @@ hard. To fix this always use named functions for non-trivial functions.
         ...
     });
 
-An exception to this rule are trivial functions that do not call any
-other functions, such as functions passed to Array.filter or
-Array.forEach.
+An exception to this rule are trivial functions that do not call any other functions, such as functions passed to Array.filter or Array.forEach.
 
-Pattern methods must always be named, and the name should be prefixed
-with the pattern name to make them easy to recognize.
+Pattern methods must always be named, and the name should be prefixed with the pattern name to make them easy to recognize.
 
 ::
 
@@ -258,34 +246,29 @@ with the pattern name to make them easy to recognize.
         _onClick: function mypatternOnClick(e) { }
     };
 
+
 Custom events
 -------------
 
-A pattern can send custom events for either internal purposes, or as a
-hook for third party JavaScript. Since IE8 is still supported
-`CustomEvent <http://dochub.io/#dom/customevent>`__ can not be used.
-Instead you must send custom events using `jQuery's trigger
-function <http://api.jquery.com/trigger/>`__. Event names must follow
-the ``pat-<pattern name>-<event name>`` pattern.
+A pattern can send custom events for either internal purposes, or as a hook for third party JavaScript.
+Since IE8 is still supported `CustomEvent <http://dochub.io/#dom/customevent>`__ can not be used.
+Instead you must send custom events using `jQuery's trigger function <http://api.jquery.com/trigger/>`__.
+Event names must follow the ``pat-<pattern name>-<event name>`` pattern.
 
 ::
 
     $(el).trigger("pat-tooltip-open");
 
-The element must be dispatched from the element that caused something to
-happen, *not* from the elements that are changed as a result of an
-action.
+The element must be dispatched from the element that caused something to happen, *not* from the elements that are changed as a result of an action.
 
-All extra data must be passed via a single object. In a future Patterns
-release this will be moved to the ``detail`` property of a CustomEvent
-instance.
+All extra data must be passed via a single object.
+In a future Patterns release this will be moved to the ``detail`` property of a CustomEvent instance.
 
 ::
 
     $(el).trigger("pat-toggle-toggled", {value: new_value});
 
-Event listeners can access the provided data as an extra parameter
-passed to the event handler.
+Event listeners can access the provided data as an extra parameter passed to the event handler.
 
 ::
 
@@ -293,12 +276,11 @@ passed to the event handler.
     }
     $(".myclass").on("pat-toggle-toggled", onToggled);
 
+
 Event listeners
 ---------------
 
-All event listeners registered using
-`jQuery.fn.on <http://api.jquery.com/on/>`__ must be namespaced with
-``pat-<pattern name>``.
+All event listeners registered using `jQuery.fn.on <http://api.jquery.com/on/>`__ must be namespaced with ``pat-<pattern name>``.
 
 ::
 
@@ -306,13 +288,12 @@ All event listeners registered using
         $el.on("click.pat-mypattern", mypattern._onClick);
     }
 
+
 Storing arbitrary data
 ----------------------
 
-When using `jQuery.fn.data <http://api.jquery.com/data/>`__ the storage
-key must either be ``pat-<pattern name>`` if a single value is stored,
-or ``pat-<pattern name>-<name>`` if multiple values are stored. This
-prevents conflicts with other code.
+When using `jQuery.fn.data <http://api.jquery.com/data/>`__ the storage key must either be ``pat-<pattern name>`` if a single value is stored, or ``pat-<pattern name>-<name>`` if multiple values are stored.
+This prevents conflicts with other code.
 
 ::
 

--- a/develop/styleguide/naming.rst
+++ b/develop/styleguide/naming.rst
@@ -5,17 +5,16 @@ Naming conventions
 
 Naming Conventions
 ==================
-Above all else,
-be consistent with any code you are modifying!
-Historically the code is all camel case,
-but new code should written following the PEP8 convention.
 
-Class names should be written in ``CamelCase`` and
-function and method names all lowercase with a underscrore seperating words (e.g. ``my_method``).
+Above all else, be consistent with any code you are modifying!
+Historically the code is all camel case, but new code should written following the PEP8 convention.
+
+Class names should be written in ``CamelCase`` and function and method names all lowercase with a underscrore seperating words (e.g. ``my_method``).
 
 
 File Conventions
 ================
+
 In Zope 2 file names used to be MixedCase.
 In Python and Plone we prefer all-lowercase filenames.
 This has the advantage that you can instantly see if you refer to a module / file or a class::
@@ -35,6 +34,5 @@ compare that to::
 
   from Products.CMFPlone.PloneUtilities import safe_hasattr
 
-The former is obviously much easier to read,
-less redundant and generally more aesthetically pleasing.
+The former is obviously much easier to read, less redundant and generally more aesthetically pleasing.
 

--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -6,8 +6,7 @@ Python styleguide
 Introduction
 ==============
 
-We've modeled the following rules and recommendations based on the following
-documents:
+We've modeled the following rules and recommendations based on the following documents:
 
  * `PEP8 <http://www.python.org/dev/peps/pep-0008>`__
  * `PEP257 <http://www.python.org/dev/peps/pep-0257>`_
@@ -15,6 +14,7 @@ documents:
  * `Google Style Guide <http://google-styleguide.googlecode.com/svn/trunk/pyguide.html>`_
  * `Pylons Coding Style <http://docs.pylonsproject.org/en/latest/community/codestyle.html>`_
  * `Tim Pope on Git commit messages <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`__
+
 
 Line length
 ===========
@@ -24,15 +24,14 @@ This includes adhering to the 80-char line length.
 If you absolutely need to break this rule, append ``# noPEP8`` to the offending line to skip it in syntax checks.
 
 .. note::
-    Configuring your editor to display a line at 79th column helps a lot
-    here and saves time.
+    Configuring your editor to display a line at 79th column helps a lot here and saves time.
 
 .. note::
-    The line length rule also applies to non-python source files, such as ``.zcml`` files,
-    but is a bit more relaxed there.
+    The line length rule also applies to non-python source files, such as ``.zcml`` files, but is a bit more relaxed there.
     It explicitly **does not** aply to documentation ``.rst`` files.
     For rst files, use *semantic* linebreaks.
     See the :doc:`REST styleguide </about/rst-styleguide.html#line-length-translations>`_ for the reasoning behind it.
+
 
 Breaking lines
 --------------
@@ -66,11 +65,16 @@ Based on code we love to look at (Pyramid, Requests, etc.), we allow the followi
            "an_exceptionally_long_string_of_characters",
        ]
 
- * Arguments on first line, directly after the opening parenthesis are forbidden when breaking lines.
- * The last argument line needs to have a trailing comma (to be nice to the next developer coming in to add something as an argument and minimize VCS diffs in these cases).
- * The closing parenthesis or bracket needs to have the same indentation level as the first line.
- * Each line can only contain a single argument.
- * The same style applies to dicts, lists, return calls, etc.
+* Arguments on first line, directly after the opening parenthesis are forbidden when breaking lines.
+
+* The last argument line needs to have a trailing comma (to be nice to the next developer coming in to add something as an argument and minimize VCS diffs in these cases).
+
+* The closing parenthesis or bracket needs to have the same indentation level as the first line.
+
+* Each line can only contain a single argument.
+
+* The same style applies to dicts, lists, return calls, etc.
+
 
 autopep8
 --------
@@ -114,9 +118,8 @@ This skips the following changes:
 - W690: Fix various deprecated code (via lib2to3). (Can be bad for
   Python 2.4.)
 
-- E721: Use `isinstance()` instead of comparing types directly. (There
-  are uses of this in for example GenericSetup and plone.api that must
-  not be fixed.)
+- E721: Use `isinstance()` instead of comparing types directly.
+  (There are uses of this in for example GenericSetup and plone.api that must not be fixed.)
 
 - E711: Fix comparison with None.  (This can break SQLAlchemy code.)
 
@@ -124,36 +127,30 @@ You can check what would be changed by one specific code::
 
     autopep8 --diff --select E309 -r .
 
+
 Indentation
 ===========
 
-For Python files, we stick with the `PEP 8 recommondation
-<http://www.python.org/dev/peps/pep-0008/#indentation>`_: Use 4 spaces per
-indentation level.
+For Python files, we stick with the `PEP 8 recommondation <http://www.python.org/dev/peps/pep-0008/#indentation>`_: Use 4 spaces per indentation level.
 
-For ZCML and XML (GenericSetup) files, we recommend the `Zope Toolkit's coding
-style on ZCML <http://docs.zope.org/zopetoolkit/codingstyle/zcml-style.html>`_
-::
+For ZCML and XML (GenericSetup) files, we recommend the `Zope Toolkit's coding style on ZCML <http://docs.zope.org/zopetoolkit/codingstyle/zcml-style.html>`_::
 
-  Indentation of 2 characters to show nesting, 4 characters to list attributes
-  on separate lines. This distinction makes it easier to see the difference
-  between attributes and nested elements.
+  Indentation of 2 characters to show nesting, 4 characters to list attributes on separate lines.
+  This distinction makes it easier to see the difference between attributes and nested elements.
 
 
 Quoting
 =======
 
-For strings and such prefer using single quotes over double quotes. The reason
-is that sometimes you do need to write a bit of HTML in your python code, and
-HTML feels more natural with double quotes so you wrap HTML string into single
-quotes. And if you are using single quotes for this reason, then be consistent
-and use them everywhere.
+For strings and such prefer using single quotes over double quotes.
+The reason is that sometimes you do need to write a bit of HTML in your python code, and HTML feels more natural with double quotes so you wrap HTML string into single quotes.
+And if you are using single quotes for this reason, then be consistent and use them everywhere.
 
 There are two exceptions to this rule:
 
 * docstrings should always use double quotes (as per PEP-257).
-* if you want to use single quotes in your string, double quotes might make
-  more sense so you don't have to escape those single quotes.
+
+* if you want to use single quotes in your string, double quotes might make more sense so you don't have to escape those single quotes.
 
 .. sourcecode:: python
 
@@ -173,14 +170,11 @@ There are two exceptions to this rule:
 Docstrings style
 ================
 
-Read and follow http://www.python.org/dev/peps/pep-0257/. There is one
-exception though: We reject BDFL's recommendation about inserting a blank line
-between the last paragraph in a multi-line docstring and its closing quotes as
-it's Emacs specific and two Emacs users here on the Beer & Wine Sprint both
-support our way.
+Read and follow http://www.python.org/dev/peps/pep-0257/.
+There is one exception though: We reject BDFL's recommendation about inserting a blank line between the last paragraph in a multi-line docstring and its closing quotes as it's Emacs specific and two Emacs users here on the Beer & Wine Sprint both support our way.
 
-The content of the docstring must be written in the active first-person form,
-e.g. "Calculate X from Y" or "Determine the exact foo of bar".
+The content of the docstring must be written in the active first-person form, e.g.
+"Calculate X from Y" or "Determine the exact foo of bar".
 
 .. sourcecode:: python
 
@@ -194,9 +188,7 @@ e.g. "Calculate X from Y" or "Determine the exact foo of bar".
         newline preceding the ending quote.
         """
 
-If you wanna be extra nice, you are encouraged to document your method's
-parameters and their return values in a `reST field list syntax
-<http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_.
+If you wanna be extra nice, you are encouraged to document your method's parameters and their return values in a `reST field list syntax <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#field-lists>`_.
 
 .. sourcecode:: rest
 
@@ -206,28 +198,23 @@ parameters and their return values in a `reST field list syntax
     :type bar: int
     :returns: something
 
-Check out the `plone.api source
-<https://github.com/plone/plone.api/tree/master/src/plone/api>`_ for more
-usage examples. Also, see the following for examples on how to write
-good *Sphinxy* docstrings: http://stackoverflow.com/questions/4547849/good-examples-of-python-docstrings-for-sphinx.
+Check out the `plone.api source <https://github.com/plone/plone.api/tree/master/src/plone/api>`_ for more usage examples.
+Also, see the following for examples on how to write good *Sphinxy* docstrings: http://stackoverflow.com/questions/4547849/good-examples-of-python-docstrings-for-sphinx.
 
 
 Unit tests style
 ================
 
-Read http://www.voidspace.org.uk/python/articles/unittest2.shtml to learn what
-is new in :mod:`unittest2` and use it.
+Read http://www.voidspace.org.uk/python/articles/unittest2.shtml to learn what is new in :mod:`unittest2` and use it.
 
-This is not true for in-line documentation tests. Those still use old unittest
-test-cases, so you cannot use ``assertIn`` and similar.
+This is not true for in-line documentation tests.
+Those still use old unittest test-cases, so you cannot use ``assertIn`` and similar.
 
 
 String formatting
 =================
 
-As per http://docs.python.org/2/library/stdtypes.html#str.format, we should
-prefer the new style string formatting (``.format()``) over the old one
-(``% ()``).
+As per http://docs.python.org/2/library/stdtypes.html#str.format, we should prefer the new style string formatting (``.format()``) over the old one (``% ()``).
 
 Also use numbering, like so:
 
@@ -252,15 +239,14 @@ because Python 2.6 supports only explicitly numbered placeholders.
 About imports
 =============
 
-1. Don't use ``*`` to import *everything* from a module, because if you do,
-   pyflakes cannot detect undefined names (W404).
+1. Don't use ``*`` to import *everything* from a module, because if you do, pyflakes cannot detect undefined names (W404).
+
 2. Don't use commas to import multiple things on a single line.
-   Some developers use IDEs (like `Eclipse <http://pydev.org/>`_) or tools
-   (such as `mr.igor <http://pypi.python.org/pypi/mr.igor>`_)
-   that expect one import per line.
+   Some developers use IDEs (like `Eclipse <http://pydev.org/>`_) or tools (such as `mr.igor <http://pypi.python.org/pypi/mr.igor>`_) that expect one import per line.
    Let's be nice to them.
-3. Don't use relative paths, again to be nice to people using certain IDEs and
-   tools. Also `Google Python Style Guide` recommends against it.
+
+3. Don't use relative paths, again to be nice to people using certain IDEs and tools.
+   Also `Google Python Style Guide` recommends against it.
 
    .. sourcecode:: python
 
@@ -277,10 +263,9 @@ About imports
        from plone.app.testing import *
        from zope.component import getMultiAdapter, getSiteManager
 
-4. Don't catch ``ImportError`` to detect whether a package is available or not,
-   as it might hide circular import errors. Instead, use
-   ``pkg_resources.get_distribution`` and catch ``DistributionNotFound``. More
-   background at http://do3.cc/blog/2010/08/20/do-not-catch-import-errors,-use-pkg_resources/.
+4. Don't catch ``ImportError`` to detect whether a package is available or not, as it might hide circular import errors.
+   Instead, use ``pkg_resources.get_distribution`` and catch ``DistributionNotFound``.
+   More background at http://do3.cc/blog/2010/08/20/do-not-catch-import-errors,-use-pkg_resources/.
 
    .. sourcecode:: python
 
@@ -309,10 +294,10 @@ About imports
 Grouping and sorting
 --------------------
 
-Since Plone has such a huge code base,
-we don't want to lose developer time figuring out into which group some import goes (standard lib?, external package?, etc.).
-So we just sort everything alphabetically case insensitive and insert one blank line between ``from foo import bar`` and ``import baz`` blocks. Conditional imports come last. Again, we *do not* distinguish between what is standard lib,
-external package or internal package in order to save time and avoid the hassle of explaining which is which.
+Since Plone has such a huge code base, we don't want to lose developer time figuring out into which group some import goes (standard lib?, external package?, etc.).
+So we just sort everything alphabetically case insensitive and insert one blank line between ``from foo import bar`` and ``import baz`` blocks.
+Conditional imports come last.
+Again, we *do not* distinguish between what is standard lib, external package or internal package in order to save time and avoid the hassle of explaining which is which.
 
 .. sourcecode:: python
 
@@ -334,8 +319,7 @@ external package or internal package in order to save time and avoid the hassle 
     else:
         HAS_DEXTERITY = True
 
-`isort <http://pypi.python.org/pypi/isort>`_,
-a python tool to sort imports can be configured to sort exactly as described above.
+`isort <http://pypi.python.org/pypi/isort>`_, a python tool to sort imports can be configured to sort exactly as described above.
 
 Add the following::
 
@@ -350,27 +334,19 @@ To either ``.isort.cfg`` or changing the header from ``[settings]`` to ``[isort]
 
 You can also use `plone.recipe.codeanalysis <http://pypi.python.org/pypi/plone.recipe.codeanalysis>`_ with the `flake8-isort <https://pypi.python.org/pypi/flake8-isort>`_ plugin enabled to check for it.
 
+
 Declaring dependencies
 ======================
 
-All direct dependencies should be declared in ``install_requires`` or
-``extras_require`` sections in ``setup.py``. Dependencies, which are not needed for
-a production environment (like "develop" or "test" dependencies) or are
-optional (like "Archetypes" or "Dexterity" flavors of the same package) should
-go in ``extras_require``. Remember to document how to enable specific features
-(and think of using ``zcml:condition`` statements, if you have such optional
-features).
+All direct dependencies should be declared in ``install_requires`` or ``extras_require`` sections in ``setup.py``.
+Dependencies, which are not needed for a production environment (like "develop" or "test" dependencies) or are optional (like "Archetypes" or "Dexterity" flavors of the same package) should go in ``extras_require``.
+Remember to document how to enable specific features (and think of using ``zcml:condition`` statements, if you have such optional features).
 
-Generally all direct dependencies (packages directly imported or used in ZCML)
-should be declared, even if they would already be pulled in by other
-dependencies. This explicitness reduces possible runtime errors and gives a
-good overview on the complexity of a package.
+Generally all direct dependencies (packages directly imported or used in ZCML) should be declared, even if they would already be pulled in by other dependencies.
+This explicitness reduces possible runtime errors and gives a good overview on the complexity of a package.
 
-For example, if you depend on ``Products.CMFPlone`` and use ``getToolByName``
-from ``Products.CMFCore``, you should also declare the ``CMFCore`` dependency
-explicitly, even though it's pulled in by Plone itself. If you use namespace
-packages from the Zope distribution like ``Products.Five`` you should
-explicitly declare ``Zope`` as dependency.
+For example, if you depend on ``Products.CMFPlone`` and use ``getToolByName`` from ``Products.CMFCore``, you should also declare the ``CMFCore`` dependency explicitly, even though it's pulled in by Plone itself.
+If you use namespace packages from the Zope distribution like ``Products.Five`` you should explicitly declare ``Zope`` as dependency.
 
 Inside each group of dependencies, lines should be sorted alphabetically.
 
@@ -378,8 +354,7 @@ Inside each group of dependencies, lines should be sorted alphabetically.
 Versioning scheme
 =================
 
-For software versions, use a sequence-based versioning scheme, which is
-`compatible with setuptools <http://pythonhosted.org/setuptools/setuptools.html#specifying-your-project-s-version>`_::
+For software versions, use a sequence-based versioning scheme, which is `compatible with setuptools <http://pythonhosted.org/setuptools/setuptools.html#specifying-your-project-s-version>`_::
 
     MAJOR.MINOR[.MICRO][.STATUS]
 
@@ -401,39 +376,33 @@ You can test it with setuptools::
     >>> parse_version('1.1.dev') == parse_version('1.1.dev0')
     True
 
-Setuptools recommends to seperate parts with a dot. The website about `semantic
-versioning <http://semver.org/>`_ is also worth a read.
+Setuptools recommends to seperate parts with a dot.
+The website about `semantic versioning <http://semver.org/>`_ is also worth a read.
 
 
 Concrete Rules
 ==============
 
 - Do not use tabs in Python code!
-  Use spaces as indenting,
-  4 spaces for each level.
-  We don't **"require"** `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_,
-  but most people use it and it's good for you.
+  Use spaces as indenting, 4 spaces for each level.
+  We don't **"require"** `PEP8 <http://www.python.org/dev/peps/pep-0008/>`_, but most people use it and it's good for you.
 
-- Indent properly,
-  even in HTML.
+- Indent properly, even in HTML.
 
 - Never use a bare except.
   Anything like ``except: pass`` will likely be reverted instantly.
 
 - Avoid ``tal:on-error``, since this swallows exceptions.
 
-- Don't use ``hasattr()`` - this swallows exceptions,
-  use ``getattr(foo, 'bar', None)`` instead.
+- Don't use ``hasattr()`` - this swallows exceptions, use ``getattr(foo, 'bar', None)`` instead.
   The problem with swallowed exceptions is not just poor error reporting.
-  This can also mask ``ConflictErrors``,
-  which indicate that something has gone wrong at the `ZODB level <http://developer.plone.org/troubleshooting/transactions.html#conflicterror>`_!
+  This can also mask ``ConflictErrors``, which indicate that something has gone wrong at the `ZODB level <http://developer.plone.org/troubleshooting/transactions.html#conflicterror>`_!
 
-- Never put any HTML in Python code and return it as a string. There are exceptions, though.
+- Never put any HTML in Python code and return it as a string.
+  There are exceptions, though.
 
-- Do not acquire anything unless absolutely necessary,
-  especially tools.
-  For example,
-  instead of using ``context.plone_utils``, use::
+- Do not acquire anything unless absolutely necessary, especially tools.
+  For example, instead of using ``context.plone_utils``, use::
 
     from Products.CMFCore.utils import getToolByName
     plone_utils = getToolByName(context, 'plone_utils')

--- a/develop/styleguide/python.rst
+++ b/develop/styleguide/python.rst
@@ -297,6 +297,7 @@ Grouping and sorting
 Since Plone has such a huge code base, we don't want to lose developer time figuring out into which group some import goes (standard lib?, external package?, etc.).
 So we just sort everything alphabetically case insensitive and insert one blank line between ``from foo import bar`` and ``import baz`` blocks.
 Conditional imports come last.
+Don't use multi-line imports but import each identifier from a module in a separate line.
 Again, we *do not* distinguish between what is standard lib, external package or internal package in order to save time and avoid the hassle of explaining which is which.
 
 .. sourcecode:: python
@@ -304,6 +305,8 @@ Again, we *do not* distinguish between what is standard lib, external package or
     # GOOD
     from __future__ import division
     from Acquisition import aq_inner
+    from datetime import datetime
+    from datetime import timedelta
     from plone.api import portal
     from plone.api.exc import MissingParameterError
     from Products.CMFCore.interfaces import ISiteRoot
@@ -376,7 +379,7 @@ You can test it with setuptools::
     >>> parse_version('1.1.dev') == parse_version('1.1.dev0')
     True
 
-Setuptools recommends to seperate parts with a dot.
+Setuptools recommends to separate parts with a dot.
 The website about `semantic versioning <http://semver.org/>`_ is also worth a read.
 
 


### PR DESCRIPTION
@gforcada please review
especially this commit: https://github.com/plone/documentation/commit/fb9c20ba00d37c07a2035510603d6c55cdbd2b93
the first commit is only reformating lines to have one line per sentence and two empty lines between sections in all styleguide files.
