### PR TITLE
fix contentrules robottest with extra save step

### DIFF
--- a/working-with-content/managing-content/contentrules.rst
+++ b/working-with-content/managing-content/contentrules.rst
@@ -138,11 +138,12 @@ In this example, you're going to create a content rule that will send an email a
        Capture and crop page screenshot
        ...  ${CURDIR}/../../_robot/contentrules-add.png
                ...  css=#content
-
        Click button  css=#form-buttons-save
        Capture and crop page screenshot
        ...  ${CURDIR}/../../_robot/contentrules-conditions.png
                ...  css=#content
+       Click button  name=form.button.Save
+
 
     assign rule
         Go to  ${PLONE_URL}/news


### PR DESCRIPTION
Fixes #.

Improves: robottest for the working-with-content/managing-content/contentrules section

Changes proposed in this pull request:
- an extra press on a 'save' button is needed. This is changed behaviour between Plone 5.0 and 5.0.2

This was first noticed in https://github.com/plone/papyrus/issues/92 but is unrelated to the version changes there; this fixes the robot-tests so they are correct for Plone 5.0.2+. 

The version changes proposed in https://github.com/plone/papyrus/issues/92 work fine, btw.
