### PR TITLE
Change console to shell

### DIFF
--- a/about/rst-styleguide.rst
+++ b/about/rst-styleguide.rst
@@ -264,7 +264,7 @@ Setting the highlighting mode for the whole document:
 
 .. code-block:: rst
 
-   .. highlight:: console
+   .. highlight:: shell
 
    All code blocks in this doc use console highlighting by default::
 

--- a/manage/installing/installation.rst
+++ b/manage/installing/installation.rst
@@ -126,7 +126,7 @@ Download the latest Plone unified installer
 Download from `the plone.org download page <http://plone.org/download>`_ to your server using wget command. Curl also works.
 Substitute the latest version number for 5.0 in the instructions below.
 
-.. code-block:: console
+.. code-block:: shell
 
     wget --no-check-certificate https://launchpad.net/plone/5.0/5.0.2/+download/Plone-5.0.2-UnifiedInstaller.tgz
 
@@ -135,13 +135,13 @@ Run the Plone installer in standalone mode
 
 Extract the downloaded file
 
-.. code-block:: console
+.. code-block:: shell
 
     tar -xf Plone-5.0.2-UnifiedInstaller.tgz
 
 Go the folder containing installer script
 
-.. code-block:: console
+.. code-block:: shell
 
     cd Plone-5.0.2-UnifiedInstaller
 
@@ -152,7 +152,7 @@ Go the folder containing installer script
 
 Run script
 
-.. code-block:: console
+.. code-block:: shell
 
   ./install.sh
 
@@ -205,7 +205,7 @@ Install the Plone developer tools
 
 If you're using this Plone install for development, add the common development tool set.
 
-.. code-block:: console
+.. code-block:: shell
 
     cd ~/Plone/zinstance
     bin/buildout -c develop.cfg
@@ -217,7 +217,7 @@ Start Plone
 
 If you're developing, start Plone in foreground mode for a test run (you'll see potential errors in the console):
 
-.. code-block:: console
+.. code-block:: shell
 
     cd ~/Plone/zinstance
     bin/plonectl fg
@@ -226,14 +226,14 @@ When you start Plone in the foreground, it runs in debug mode, which is much slo
 
 For evaluation, instead use:
 
-.. code-block:: console
+.. code-block:: shell
 
     cd ~/Plone/zinstance
     bin/plonectl start
 
 Use
 
-.. code-block:: console
+.. code-block:: shell
 
     cd ~/Plone/zinstance
     bin/plonectl stop


### PR DESCRIPTION
Fixes: #

Improves: Readability 

Changes proposed in this pull request:
- for the use of command line, like 'apt-get' or other commands we use the cde-block:: shell, this will add
  a 'command prompt' [$] automatically to the beginning / in front of the command.

This is now done via CSS in our theme [ https://github.com/plone/sphinx.themes.plone/commit/ae70d04669b871eeb8e0c1c025180ca4520caea1 ] and is not getting in the way for copy and paste, since you can not select it, meaning:

```
$ apt-get
```

If you do here now copy and paste you can only copy

```
apt-get
```
- By doing this, we can remove all the 'loose' '$' signs though the docs, which is better for spell-check, and we can't forget it because sphinx will add these.
## 
