### PR TITLE
wait for FF on slower machines

### DIFF
--- a/working-with-content/managing-content/contentrules.rst
+++ b/working-with-content/managing-content/contentrules.rst
@@ -142,6 +142,8 @@ In this example, you're going to create a content rule that will send an email a
        Capture and crop page screenshot
        ...  ${CURDIR}/../../_robot/contentrules-conditions.png
                ...  css=#content
+       Wait until element is visible
+       ...  name=form.button.Save
        Click button  name=form.button.Save
 
 


### PR DESCRIPTION
Fixes: #

Improves: makes robotscreenshot work on slower machines, where some forms take a long time to render. Solution: check if the button you want to click, is visible.

Changes proposed in this pull request:
