### PR TITLE
reduce nesting in the develop section

### DIFF
--- a/develop/index.rst
+++ b/develop/index.rst
@@ -1,62 +1,48 @@
 Developing for Plone
 ====================
 
-
-Developing add-ons
-------------------
+An overview of all documentation for developers, both for writing your own add-ons and for working with Plone itself.
 
 .. toctree::
    :maxdepth: 2
 
-   addons/index
-
-Programming with Plone
-----------------------
+   Developing add-ons for Plone <addons/index>
 
 .. toctree::
    :maxdepth: 2
 
-   plone/index
-
-
-Debugging Plone
----------------
+   Programming with Plone <plone/index>
 
 .. toctree::
    :maxdepth: 2
 
-   debugging/index
-
-
-Testing Plone
--------------
+   Debugging <debugging/index>
 
 .. toctree::
    :maxdepth: 2
 
-   testing/index
+   Writing tests <testing/index>
 
 
-Developing for Plone Core
--------------------------
-
-.. toctree::
-   :maxdepth: 4
-
-   coredev/docs/index
-
-
-The Plone Style Guide
----------------------
+Developing for Plone Core follows similar patterns, but it requires you to sign the Plone Contributor license.
+The process is documented here.
 
 .. toctree::
    :maxdepth: 2
 
-   styleguide/index
+
+   The process for developing for Plone core <coredev/docs/index>
+
+Writing proper code and documentation that others can expand upon is vital.
+As Plone community, we stick to the following style guides, and ask that all developers and documentation writers do the same.
+
+.. toctree::
+   :maxdepth: 2
+
+   Plone style guides <styleguide/index>
 
 
-Importing content from other systems
-------------------------------------
+Importing content from other systems often requires the help of tools to get content out from various sources and into Plone. A number of these tools exist.
 
 .. toctree::
    :maxdepth: 2
@@ -89,14 +75,16 @@ Selected Plone core package documentation
 
 plone.api
 ^^^^^^^^^
+plone.api is the recommended way of accessing Plone's functionality in your own code.
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
-   plone.api/docs/index
+   full plone.api documentaton <plone.api/docs/index>
 
 plone.app.multilingual
 ^^^^^^^^^^^^^^^^^^^^^^
+The default solution to create multilingual content.
 
 .. toctree::
    :maxdepth: 1
@@ -105,6 +93,7 @@ plone.app.multilingual
 
 plone.app.contenttypes
 ^^^^^^^^^^^^^^^^^^^^^^
+The default dexterity-based content types, since Plone 5.
 
 .. toctree::
    :maxdepth: 1
@@ -117,13 +106,15 @@ plone.app.contentlisting
 .. toctree::
    :maxdepth: 1
 
-   /external/plone.app.contentlisting/docs/README
+   /external/plone.app.contentlisting/README
 
 plone.app.event
 ^^^^^^^^^^^^^^^
 
+The calendar framework for Plone, default since Plone 5.
+
 .. toctree::
    :maxdepth: 1
 
-   /external/plone.app.event/docs/index
+   plone.app.event documentation </external/plone.app.event/docs/index>
 

--- a/develop/plone/index.rst
+++ b/develop/plone/index.rst
@@ -1,5 +1,5 @@
-Programming Plone
-=================
+Programming with Plone
+======================
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Fixes: #580 #470

Improves: narrative explanation of the development sections

Changes proposed in this pull request:
- override the descriptions of external indexes in toc
- add some descriptive lines between sections
- fixed erroneous link to plone.app.contentlisting
