### PR TITLE
Replace grok/plone.directives and small formal fixes

### DIFF
--- a/develop/addons/schema-driven-forms/customising-form-behaviour/actions.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/actions.rst
@@ -27,7 +27,7 @@ in our pizza order form:
         def handleCancel(self, action):
             ...
 
-The name of the method is not particularly important, so long as it is
+The name of the method is not particularly important, but it needs to be
 unique. The body of the handler function may react to the button however
 is appropriate for the form’s use case. It may perform a redirect or
 update form properties prior to re-rendering of the form. It should not
@@ -87,7 +87,7 @@ Updating button properties
 As with regular widgets, it is sometimes useful to set properties on
 buttons after they have been instantiated by *z3c.form*. One common
 requirement is to add a CSS class to the button. The standard edit form
-in*plone.directives.form* does this, for example, to add Plone’s
+in *plone.directives.form* does this, for example, to add Plone’s
 standard CSS classes. The usual approach is to override
 *updateActions()*, which is called during the form update cycle:
 

--- a/develop/addons/schema-driven-forms/customising-form-behaviour/fieldsets.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/fieldsets.rst
@@ -30,13 +30,10 @@ purely for aesthetic effect.
 
 ::
 
-    from five import grok
-    from plone.supermodel import model
-    from plone.directives import form
-
-    from zope import schema
-
     from example.dexterityforms.interfaces import MessageFactory as _
+    from plone.autoform import directives as form
+    from plone.supermodel import model
+    from zope import schema
 
     ...
 

--- a/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
@@ -183,8 +183,8 @@ Here is an example that returns our pizza types:
 
         return SimpleVocabulary(terms)
 
-Here, we have defined a function acting as the*IContextSourceBinder*, as
-specified via the @*grok.provider()* decorator. This looks up the
+Here, we have defined a function acting as the *IContextSourceBinder*, as
+specified via the *@grok.provider()* decorator. This looks up the
 registry and looks for the record we created with *registry.xml* above
 (remember to re-install the product in the Add-on control panel or the
 *portal\_quickinstaller* tool if you modify this file). We then use the
@@ -252,7 +252,7 @@ initialised with the registry key
             return SimpleVocabulary(terms)
 
 Notice how in our first implementation, the function *provided* the
-*IContextSourceBinder*interface, but the class here *implements* it.
+*IContextSourceBinder* interface, but the class here *implements* it.
 This is because the function was the context source binder callable
 itself. Conversely, the class is a factory that creates
 *IContextSourceBinder* objects, which in turn are callable.


### PR DESCRIPTION
Improves: 
- replace mentions of plone.directives from fieldsets.rst
- several small formal fixes, like missing spaces and wording
