### PR TITLE
Fix links to changelogs

### DIFF
--- a/about/index.rst
+++ b/about/index.rst
@@ -15,6 +15,6 @@ About this documentation
 Changelog
 ---------
 
-- `Changelog of documenation for Plone 5.1 <https://github.com/plone/documentation/blob/5.0/CHANGES.rst>`_
+- `Changelog of documenation for Plone 5.0 <https://github.com/plone/documentation/blob/5.0/CHANGES.rst>`_
 - `Changelog of papyrus <https://github.com/plone/papyrus/blob/5.0/CHANGES.rst>`_ [documenation build tool]
 - `Changelog of the documentation theme <https://github.com/plone/sphinx.themes.plone/blob/master/CHANGES.rst>`_

--- a/about/index.rst
+++ b/about/index.rst
@@ -15,5 +15,6 @@ About this documentation
 Changelog
 ---------
 
-.. toctree::
-    :maxdepth: 2
+- `Changelog of documenation for Plone 5.1 <https://github.com/plone/documentation/blob/5.0/CHANGES.rst>`_
+- `Changelog of papyrus <https://github.com/plone/papyrus/blob/5.0/CHANGES.rst>`_ [documenation build tool]
+- `Changelog of the documentation theme <https://github.com/plone/sphinx.themes.plone/blob/master/CHANGES.rst>`_


### PR DESCRIPTION
Fixes: #641

Improves: Now user are able to find the list of changes more easily

Changes proposed in this pull request:
- update about/index with links of change-logs of docs,papyrus and the theme 
## 
## 
