### PR TITLE
secureSend has been deprecated. To use send

### DIFF
--- a/working-with-content/managing-content/ploneformgen/failsafe_email.rst
+++ b/working-with-content/managing-content/ploneformgen/failsafe_email.rst
@@ -51,6 +51,6 @@ Example PloneFormGen script adapter (using proxy role Manager)::
 
     for email in emails:
       try:
-        mailhost.secureSend(message, email, source, subject=subject, subtype='plain', charset="utf-8", debug=False, From=source)
+        mailhost.send(message, email, source, subject=subject, charset="utf-8", )
       except Exception:
         pass


### PR DESCRIPTION
Fixes: #

Improves:

Changes proposed in this pull request:
## 
## 
## 

same as #634
