### PR TITLE
Fix reference

### DIFF
--- a/develop/plone/content/dexterity.rst
+++ b/develop/plone/content/dexterity.rst
@@ -22,10 +22,7 @@ with Plone 4.
 mr.bob templates
 ================
 
-Please see :doc:`ZopeSkel page </develop/addons/bobtemplates.plone/README>` for project skeleton templates for Dexterity.
-
-
-
+Please see :doc:`bobtemplates.plone page </develop/addons/bobtemplates.plone/README>` for project skeleton templates for Dexterity.
 
 Content creation permissions
 =============================


### PR DESCRIPTION
Fixes: #

Improves:

Changes proposed in this pull request:
- Fix a reference to bobtemplates.plone that was named zopeskel

It should be backported to 5.0 branch I guess :-)
