### PR TITLE
Fixed link to bobtemplates.plone in types documentation.

### DIFF
--- a/develop/plone/content/types.rst
+++ b/develop/plone/content/types.rst
@@ -194,7 +194,7 @@ Dexterity
 
 * Use Dexterity control panel in site setup
 
-* Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone>`
+* Use :doc:`bobtemplates.plone </develop/addons/bobtemplates.plone/README>`
 
 Plomino (Archetypes-based add-on)
 ---------------------------------
@@ -286,4 +286,3 @@ The default addable types are the types that are addable when
 ``constrainTypesMode`` is ``0`` (i.e not enabled).
 
 For more information, see **Products/CMFPlone/interfaces/constraints.py**
-


### PR DESCRIPTION
Fixes: warning when running `make html` in papyrus:

```
.../papyrus/source/documentation/develop/plone/content/types.rst:197:
WARNING: unknown document: /develop/addons/bobtemplates.plone
```
