### PR TITLE
update travis, no more bootstrap.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
 - git clone https://github.com/plone/papyrus ../papyrus && cd ../papyrus
 - mkdir -p source && ln -s ../../documentation source/documentation
-- python bootstrap-buildout.py --setuptools-version=18.3.1 --version=2.4.3
+- pip install zc.buildout
 - bin/buildout -N -t 3 buildout:eggs-directory=../eggs buildout:checkout=documentation sources:documentation="git https://github.com/plone/documentation egg=false" versions:plone.app.robotframework=0.9.14
 before_script:
 - echo '[general]' > docutils.conf


### PR DESCRIPTION
Fixes: travis not working since removal of bootstrap.py from papyurs

Improves:

Changes proposed in this pull request:
- change to "pip install zc.buildout"
## 
## 

we removed bootstrap.py so travis needs to reflect that as well.
