### PR TITLE
Add: Link to cherry-pick docs

### DIFF
--- a/about/contributing.rst
+++ b/about/contributing.rst
@@ -82,7 +82,7 @@ The documentation for the different versions (Plone 3, Plone 4, Plone 5) are org
 
 The *default* branch points to the current version of Plone.
 
-Documentation changes that are valid for multiple versions of Plone can be done by making multiple pull requests, or by *cherry-picking* which may be easier to do when branches are widely different.
+Documentation changes that are valid for multiple versions of Plone can be done by making multiple pull requests, or by :doc:`cherry-picking </about/cherrypicking>` which may be easier to do when branches are widely different.
 When all this seems alien and strange, just note in your pull request that you think this is valid for other versions of Plone as well, and the documentation team will take care of doing the technical stuff.
 
 


### PR DESCRIPTION
Improves: Documentation

Changes proposed in this pull request:
- Add a link to our cherry-pick docs, which helps more than 'just' mention the name 'cherry-pick' .
## 
## 
