### PR TITLE
Specify new key for typesUseViewActionInListings

### DIFF
--- a/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
+++ b/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
@@ -511,7 +511,7 @@ Normally, you do not modify or access these records. Instead you change the sett
 +--------------------+-----------------------------------+-----------------------------------------+
 | site_properties    | disable_nonfolderish_sections     | **REMOVED**                             |
 +--------------------+-----------------------------------+-----------------------------------------+
-| site_properties    | typesUseViewActionInListings      | **TBD**                                 |
+| site_properties    | typesUseViewActionInListings      | plone.types_use_view_action_in_listings |
 +--------------------+-----------------------------------+-----------------------------------------+
 | site_properties    | verify_login_name                 | plone.verify_login_name                 |
 +--------------------+-----------------------------------+-----------------------------------------+


### PR DESCRIPTION
Fixes: #

Improves:
   portal properties to site properties documentation by specifying a missing key (typesUseViewActionInListings)

Changes proposed in this pull request:
## 
## 
## 

plone.types_use_view_action_in_listings works for me
