### PR TITLE
Update links to point to github

### DIFF
--- a/develop/plone/members/member_profile.rst
+++ b/develop/plone/members/member_profile.rst
@@ -17,10 +17,10 @@ can edit himself on his user account page.
 For more info, see:
 
 ``MemberDataTool``
-    http://svn.zope.org/Products.CMFCore/trunk/Products/CMFCore/MemberDataTool.py?rev=110418&view=auto
+    https://github.com/zopefoundation/Products.CMFCore/blob/master/Products/CMFCore/MemberDataTool.py
 
 ``MemberData`` class
-    http://svn.zope.org/Products.CMFCore/trunk/Products/CMFCore/MemberDataTool.py?rev=110418&view=auto
+    https://github.com/zopefoundation/Products.CMFCore/blob/master/Products/CMFCore/MemberDataTool.py
 
 PlonePAS subclasses and extends MemberData and MemberDataTool.
 


### PR DESCRIPTION
Changes proposed in this pull request:
- update links to point to github (rather than svn.zope.org)

It needs to be cherry-picked to 5.1 if accepted.
