### PR TITLE
Remove sentence and link

### DIFF
--- a/about/rst-styleguide.rst
+++ b/about/rst-styleguide.rst
@@ -299,9 +299,6 @@ Setting the highlighting mode for the whole document:
 
 If syntax highlighting is not enabled for your code block, you probably have a syntax error and `Pygments <http://pygments.org>`_ will fail silently.
 
-The full list of lexers and associated short names is here:
-
-
 Images
 ======
 


### PR DESCRIPTION
Fixes: broken wording

Improves: style-guide

Changes proposed in this pull request:

-

-

-



Remove link to overview of all lexer, not all of them are working in our current setup and we do not want people to 'just' pick a lexer, the ones we do use are already in our stye-guide.