### PR TITLE
Fix language check. Resolves #537

### DIFF
--- a/develop/plone/searching_and_indexing/query.rst
+++ b/develop/plone/searching_and_indexing/query.rst
@@ -436,15 +436,32 @@ the objects without triggering a security exception::
 Bypassing language check
 ========================
 
-.. note::
+.. note ::
 
         All portal_catalog() queries are limited to the selected language of
         the current user. You need to explicitly bypass the language check if you
         want to do multilingual queries.
 
-Example of how to bypass language check::
+Language is only a factor when a multilingual product is installed - which 
+basically comes down to one of the venerable ``LinguaPlone`` or the more modern 
+``plone.app.multilingual``. Bypassing the language check depends on which of 
+these you are using.
+
+In LinguaPlone and plone.app.multilingual 1.x (what you would probably use in 
+versions 4.3 or earlier of Plone), a patch is applied to the portal_catalog.  
+To bypass this add the parameter ``Language='all'`` to your catalog query like
+so::
 
     all_content_brains = portal_catalog(Language="")
+
+``plone.app.multilingual`` creates Root Language Folders for each of your site's 
+languages and keeps ("jails") content within the appropriate folders. Each Root 
+Language Folder is also a NavigationRoot, so the portal_catalog is effectively
+limited to searches in the users current language.
+This means that the way to bypass this is to add the parameter ``path='/'` to 
+your catalog query like so::
+
+    all_content_brains = portal_catalog(path='/')
 
 
 Bypassing Expired content check

--- a/develop/plone/searching_and_indexing/query.rst
+++ b/develop/plone/searching_and_indexing/query.rst
@@ -463,6 +463,13 @@ your catalog query like so::
 
     all_content_brains = portal_catalog(path='/')
 
+.. note ::
+ 
+         Although the language folders are also marked to be INavigationRoot, 
+         in LinguaPlone the language of the content is not enforced inside the 
+	 language folder (in plone.app.multilingual there's a subscriber that 
+	 moves the content to the appropriate folder).
+
 
 Bypassing Expired content check
 ===============================


### PR DESCRIPTION
First offering on fixing the above issue.  This needs review for technical accuracy - in particular that the Language parameter works for LinguaPlone.  I thought it should be the following:

    portal_catalog(Language="all")

But since I wasn't able to prove either that or Language='' works, I'm leaving the LinguaPlone part as it was.

@erral @jensens

Fixes: #537 corrects "Bypassing Language Check" in to consider plone.app.multilingual in addition to LinguaPlone

Improves:

Changes proposed in this pull request:

-

-

-


