### PR TITLE
Scratch an itch: no hyphen between content and type.

### DIFF
--- a/adapt-and-extend/custom-ct/index.rst
+++ b/adapt-and-extend/custom-ct/index.rst
@@ -1,7 +1,7 @@
-Custom Content-Types
+Custom Content Types
 ====================
 
-The recommended way to develop new custom content-types is by using :term:`Dexterity`. You'll find the full manual here.
+The recommended way to develop new custom content types is by using :term:`Dexterity`. You'll find the full manual here.
 
 .. toctree::
    :maxdepth: 1

--- a/develop/addons/upgrade_to_50.rst
+++ b/develop/addons/upgrade_to_50.rst
@@ -6,7 +6,7 @@ Archetypes
 ----------
 
 If your add-on depends on Archetypes, you will need some parts of ``Products.ATContentTypes``.
-Those parts will be declared by the profile "Archetypes-tools without content-types". It must be added to your ``profiles/default/metadata.xml`` that way::
+Those parts will be declared by the profile "Archetypes-tools without content types". It must be added to your ``profiles/default/metadata.xml`` that way::
 
     <dependencies>
         <dependency>profile-Products.ATContentTypes:base</dependency>

--- a/develop/plone/content/dynamic_views.rst
+++ b/develop/plone/content/dynamic_views.rst
@@ -34,7 +34,7 @@ dynamic view dropdown.
 If you want to restrict this ability,
 grant or revoke this permission as appropriate.
 
-This can be useful for some content-types like Dexterity ones, where
+This can be useful for some content types like Dexterity ones, where
 dynamic views are enabled by default, and the easiest way to disable
 them is using this permission.
 
@@ -356,7 +356,7 @@ Method aliases
 =================
 
 Method aliases allow you to redirect basic actions (view, edit) to
-content-type specific views.  Aliases are configured in ``portal_types``.
+content type specific views.  Aliases are configured in ``portal_types``.
 
 Other resources
 ================

--- a/develop/plone/content/types.rst
+++ b/develop/plone/content/types.rst
@@ -251,7 +251,7 @@ If ``setConstrainTypesMode`` is ``1``, then only the types enabled by using
 
 The types specified by ``setLocallyAllowedTypes`` must be a subset
 of the allowable
-types specified in the content-type's FTI (Factory Type Information) in the
+types specified in the content type's FTI (Factory Type Information) in the
 ``portal_types`` tool.
 
 If you want the types to appear in the :guilabel:

--- a/develop/plone/functionality/actions.rst
+++ b/develop/plone/functionality/actions.rst
@@ -177,10 +177,10 @@ site editor may set it from Display menu. For more information see
 Dynamic Views.
 
 
-Content-type specific actions
+Content type specific actions
 -------------------------------
 
-Content-type specific actions can be registered in portal_types.
+Content type specific actions can be registered in portal_types.
 Actions are viewable and editable in Zope Management Interface under portal_types.
 After editing actions,
 content type XML can be  exported and placed to your content type add-on product.

--- a/develop/plone/misc/flowplayer.rst
+++ b/develop/plone/misc/flowplayer.rst
@@ -20,7 +20,7 @@ Plone integration exists as an add-on product:
 Creating a custom Flowplayer
 ==============================
 
-Here is a walkthrough how to create a custom content-type with a video field
+Here is a walkthrough how to create a custom content type with a video field
 which plays the uploaded video using Flowplayer in a page template with
 parameters you define.
 

--- a/develop/plone/searching_and_indexing/indexing.rst
+++ b/develop/plone/searching_and_indexing/indexing.rst
@@ -232,7 +232,7 @@ package, `plone.indexer <https://pypi.python.org/pypi/plone.indexer>`_,
 which provides a series of primitives to delegate indexing operations
 to adapters.
 
-Let's say you have a content-type providing the interface
+Let's say you have a content type providing the interface
 ``IMyType``. To define an indexer for your type which takes the
 first 10 characters from the body text, just type (assuming the
 attribute's name is 'text'):
@@ -262,11 +262,11 @@ class providing the required ``IIndexer`` interface.
 
 To learn more about the *plone.indexer* package, read `its doctest <http://dev.plone.org/plone/browser/plone.indexer/trunk/plone/indexer/README.txt>`_.
 
-For more info about how to create content-types, refer to the :doc:`developing add-ons section </develop/addons/index>`.
-For older Archetypes content-types, see the `Plone 4 documentention on Archetypes <http://docs.plone.org/4/en/old-reference-manuals/archetypes/index.html>`_
+For more info about how to create content types, refer to the :doc:`developing add-ons section </develop/addons/index>`.
+For older Archetypes content types, see the `Plone 4 documentention on Archetypes <http://docs.plone.org/4/en/old-reference-manuals/archetypes/index.html>`_
 
 **Important note:** If you want to adapt an
-Archetypes content-type like Event or News Item, take into account
+Archetypes content type like Event or News Item, take into account
 you will have to feed the ``indexer`` decorator with the Zope 3
 interfaces defined in ``Products.ATContentTypes.interface.*``
 files, not with the deprecated Zope 2 ones into the
@@ -384,7 +384,7 @@ Some interesting columns
 
 * getRemoteURL: Where to go when the object is clicked
 
-* getIcon: Since Plone 5.0.2 - Boolean value which is set to :guilabel:``True``, when item has or is an image (used for showing thumbs in lists, portlets, etc. ). Content-type-icons (aka portaltype-icons) ( e.g.: for folder, document, news item etc.) are rendered as fontello fonts since Plone 5.0. 
+* getIcon: Since Plone 5.0.2 - Boolean value which is set to :guilabel:``True``, when item has or is an image (used for showing thumbs in lists, portlets, etc. ). Content type icons (aka portaltype-icons) ( e.g.: for folder, document, news item etc.) are rendered as fontello fonts since Plone 5.0. 
 
 * exclude_from_nav: If True the object won't appear in sitemap, navigation tree
 

--- a/develop/plone/searching_and_indexing/query.rst
+++ b/develop/plone/searching_and_indexing/query.rst
@@ -903,7 +903,7 @@ criteria:
    simple subobjects that can be set using simple Python expressions.
  * These queries are apparently much faster to execute, as well as
  * much easier to understand, and
- * content-type agnostic in the sense that they are no longer tied to
+ * content type agnostic in the sense that they are no longer tied to
    ArcheTypes.
 
 The easiest way to get into these queries is to grab a debug shell


### PR DESCRIPTION
Fixes: no issue filed

Improves: grammar

Changes proposed in this pull request:

- Removes hyphen between _content_ and _type_, except when it appears in code, HTTP headers, URLs, etc.

-

-


