### PR TITLE
remove "just-released" wording for P5

### DIFF
--- a/_templates/version_warning.html
+++ b/_templates/version_warning.html
@@ -2,8 +2,8 @@
 <div class="row">
   <div class="col-sm-12 admonition warning version_warning" >
     <p class="first admonition-title">Warning</p>
-   <p class="last">This is the documentation for the just-released Plone 5, and is updated regularly.<br />
-    There have been many changes in this version, so if you are using Plone 4 do consult the <a href="http://docs.plone.org/4/en">Plone 4.3 Documentation</a></p>
+   <p class="last">This is the documentation for Plone 5.<br />
+    There have been many changes in this version, so if you are using Plone 4 consult the <a href="http://docs.plone.org/4/en">Plone 4.3 Documentation</a></p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Fixes: #

Improves: P5 is over a year old

Changes proposed in this pull request:

- remove "just-released" when describing P5


