### PR TITLE
Start with basic QA Tests, please merge #769 first !

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,5 @@
+[WG]
+bears = WriteGoodLintBear
+allow_so_beginning = False
+files = **/*.rst
+

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+    - docker pull testthedocs/ttd.coala
+
+test:
+  override:
+    - docker run -it -v "${PWD}"/docs:/source:rw testthedocs/ttd.coala '-c=/source/.coafile' -C WG
+

--- a/circle.yml
+++ b/circle.yml
@@ -9,5 +9,5 @@ dependencies:
 
 test:
   override:
-    - docker run -it -v "${PWD}"/docs:/source:rw testthedocs/ttd.coala '-c=/source/.coafile' -C WG
+    - docker run -it -v "${PWD}":/source:rw testthedocs/ttd.coala '-c=/source/.coafile' -C WG
 


### PR DESCRIPTION

    Please, merge this PR after #769 is merged.
    Please do not cherry-pick that into 5.0 or 4.x !

This adds temporary [at least for now] CircleCI for running basiq QA-Tests against the docs.

We'll add more tests and we'll improve the test setup step by step.

In the long term, we'll hope to have all tests in one CI setup, this is not possible, yet. In order to do so, we'll first need to change our current travis setup.

Currently this test is running against all docs, this will change soon to run against the latest commit to speed up testing and make it easier/more appealing to improve the docs.

Changes proposed in this pull request:

    Add circle.yaml file
    Add .coafile



