### PR TITLE
update zcml to use for attribute rather than layer

### DIFF
--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -590,7 +590,7 @@ original.
           />
     </configure>
 
-.. Note::
+Note::
 
         We've retained the permissions and marker interface of the original view.
         You may provide a specific permission or marker interface in lieu of these

--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -585,7 +585,7 @@ original.
           name="register"
           class=".customregistration.CustomRegistrationForm"
           permission="zope2.View"
-          layer="..interfaces.IExamplePolicy"
+          for="Products.CMFPlone.Portal.PloneSite"
           />
     </configure>
 

--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -584,10 +584,17 @@ original.
       <browser:page
           name="register"
           class=".customregistration.CustomRegistrationForm"
-          permission="zope2.View"
-          for="Products.CMFPlone.Portal.PloneSite"
+          permission="cmf.AddPortalMember"
+          for="plone.app.layout.navigation.interfaces.INavigationRoot"
+          layer="example.policy.interfaces.IExamplePolicy"
           />
     </configure>
+
+.. Note::
+
+        We've retained the permissions and marker interface of the original view.
+        You may provide a specific permission or marker interface in lieu of these
+        as your product requires.
 
 * Create ``browser/customregistration.py``::
 

--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -590,10 +590,10 @@ original.
           />
     </configure>
 
-Note::
+.. note::
 
         We've retained the permissions and marker interface of the original view.
-        You may provide a specific permission or marker interface in lieu of these
+        You may provide a specific permission or marker interface instead of these
         as your product requires.
 
 * Create ``browser/customregistration.py``::


### PR DESCRIPTION
Fixes: #772 

Improves:
Updates documentation with correct zcml xml.

Changes proposed in this pull request:

- use for attribute in browser:page instead of layer when overriding class view

-

-


