### PR TITLE
fix link and note markup

### DIFF
--- a/develop/styleguide/javascript.rst
+++ b/develop/styleguide/javascript.rst
@@ -2,7 +2,9 @@
 JavaScript styleguide
 =====================
 
-*NOTE: Plone doesn't yet use any of the new `ES2015 <https://babeljs.io/docs/learn-es2015/>`__ features.*
+.. note:: 
+
+  Plone doesn't yet use any of the new `ES2015 <https://babeljs.io/docs/learn-es2015/>`__ features.
 
 Many of the style guide recommendations here come from Douglas Crockford's seminal book `JavaScript, the good parts <http://shop.oreilly.com/product/9780596517748.do>`__.
 
@@ -15,7 +17,7 @@ When editing a file, please keep to the convention already established.
 
 In `Patternslib <http://patternslib.com>`_ we indent 4 spaces as suggested by Douglas Crockford in *JavaScript, the good parts*.
 
-The `Mockup <https://github.com/plone/mockup>` patterns on the other hand indent 2 spaces.
+The `Mockup <https://github.com/plone/mockup>`_ patterns on the other hand we indent 2 spaces.
 
 
 Naming of variables, classes and functions


### PR DESCRIPTION
Fixes: #

Improves:

Changes proposed in this pull request:

- The old note wasn't displaying the external link correctly, so changed note according to the ReST style guide at https://docs.plone.org/about/rst-styleguide.html

- Fixed link to mockup repo



