### PR TITLE
Style: remove 'easily'

### DIFF
--- a/adapt-and-extend/theming/barceloneta.rst
+++ b/adapt-and-extend/theming/barceloneta.rst
@@ -78,7 +78,7 @@ The LESS resources live in the `plonetheme.barceloneta egg <https://github.com/p
     ├── variables.plone.less
     └── views.plone.less
 
-They are divided by base styling, layout, function, components and views, so they could be easily reusable and extended from other themes.
+They are divided by base styling, layout, function, components and views, so they could be reusable and extended from other themes.
 The main LESS resource that imports all the others is ``barceloneta.plone.less``.
 
 It has a set of LESS variables that can be overriden either through the web using the `Theming control panel <http://docs.plone.org/external/plone.app.theming/docs/index.html#using-the-control-panel>`_ or by reusing it in your own theme.
@@ -99,7 +99,7 @@ Whenever possible additional classes and ids were introduced being always domain
 Register LESS resources profile
 ===============================
 
-Barceloneta provides an optional GenericSetup profile that allows you to easily reuse the resources from the LESS files of your theme.
+Barceloneta provides an optional GenericSetup profile that allows you to reuse the resources from the LESS files of your theme.
 This is done by registering all the Barceloneta LESS resources as Plone Resource Registries resources.
 This profile is called ``plonetheme.barceloneta:registerless`` and can be imported from an external theme GenericSetup profile ``metadata.xml`` like:
 

--- a/adapt-and-extend/theming/templates_css/template_basics.rst
+++ b/adapt-and-extend/theming/templates_css/template_basics.rst
@@ -495,7 +495,7 @@ This blanks out the ``column_one_slot`` and ``column_two_slot`` slots.
 Head slots
 ================
 
-You can easily include per-template CSS and JavaScript in the ``<head>``
+You can include per-template CSS and JavaScript in the ``<head>``
 element using extra slots defined in Plone's ``main_template.pt``.
 
 Note that these media files do not participate in

--- a/appendices/glossary.rst
+++ b/appendices/glossary.rst
@@ -301,7 +301,7 @@ This is a glossary for some definitions used in this documentation and still und
         and other add-ons, and is a useful place to find the very latest
         code for hundreds of add-ons to Plone. Developers of new Plone
         Products are encouraged to share their code via the Collective so
-        that others can easily find it, use it, and contribute fixes and
+        that others can find it, use it, and contribute fixes and
         improvements.
 
     Sprint

--- a/develop/addons/components/genericsetup.rst
+++ b/develop/addons/components/genericsetup.rst
@@ -5,7 +5,7 @@ Add-on installation and export framework: GenericSetup
 .. admonition:: Description
 
     GenericSetup is a framework to modify the Plone site during add-on package installation and uninstallation.
-    It provides XML-based rules to change the site settings easily.
+    It provides XML-based rules to change the site settings.
 
 
 Introduction
@@ -329,7 +329,7 @@ Best practice for all versions of GenericSetup is this:
 Custom installer code (``setuphandlers.py``)
 ============================================
 
-Besides out-of-the-box XML steps which easily provide both install and uninstall,
+Besides out-of-the-box XML steps which provide both install and uninstall,
 GenericSetup provides a way to run custom Python code when your add-on package is installed and uninstalled.
 This is not a very straightforward process, though.
 

--- a/develop/addons/components/utilities.rst
+++ b/develop/addons/components/utilities.rst
@@ -4,8 +4,7 @@ Utilities
 
 .. admonition:: Description
 
-    Utility design pattern in Zope 3 allows easily overridable singleton class instances
-    for your code.
+    Utility design pattern in Zope 3 allows overridable singleton class instances for your code.
 
 
 Introduction

--- a/develop/addons/javascript/ajax.rst
+++ b/develop/addons/javascript/ajax.rst
@@ -44,7 +44,7 @@ Below is an example how to work around this for jQuery getJSON() calls by
   to make server-to-server call and return it as it would be a local call, thus
   working around cross-domain restriction
 
-This example is for Plone, but the code is easily port to other web frameworks.
+This example is for Plone, but the code is portable to other web frameworks.
 
 .. note::
 

--- a/develop/addons/schema-driven-forms/creating-a-simple-form/testing-the-form.rst
+++ b/develop/addons/schema-driven-forms/creating-a-simple-form/testing-the-form.rst
@@ -21,7 +21,7 @@ control panel. This should also install the product called *Plone
 z3c.form support* (from the *plone.app.z3cform* package) as a
 dependency.
 
-We haven’t created any links to the form yet (though you could easily do
+We haven’t created any links to the form yet (though you could do
 so in a content item or portlet by inserting a manually-entered URL),
 but the form can be visited by going to the *@@order-pizza* view on the
 Plone site root, e.g.:

--- a/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
@@ -147,7 +147,7 @@ This is simply a callable (usually a function or an object with a
 *\_\_call\_\_* method) that provides the *IContextSourceBinder*
 interface and takes a *context* parameter. The *context* argument is the
 context of the form view. The callable should return a vocabulary, which
-is most easily achieved by using the *SimpleVocabulary* class from
+is achieved by using the *SimpleVocabulary* class from
 *zope.schema*.
 
 Here is an example that returns our pizza types:
@@ -225,7 +225,7 @@ Sometimes, it is useful to parameterise the source. For example, we
 could generalise the pizza source to work with any registry value
 containing a sequence, by passing the registry key as an argument. This
 would allow us to create many similar vocabularies and call upon them in
-code easily.
+code.
 
 This degree of generalisation is probably overkill for our use case, but
 to illustrate the point, we’ll outline the solution below.

--- a/develop/import/index.rst
+++ b/develop/import/index.rst
@@ -28,7 +28,7 @@ Transmogrify
 By far the most flexible tool available is something called **collective.transmogrifier**.
 
 .. note::
-	
+
 	A transmogrifier is fictional device used for transforming one object into another object. The term was coined by Bill Waterson of Calvin and Hobbes fame.
 
 In principle, what it does is to allow you to lay a 'pipeline', whereby an object (a piece of content) is transported. At each part of the pipeline, you can perform various operations on it: extract, change, add metadata, etcetera. These operations are in the form of so-called 'blueprints'.
@@ -53,7 +53,7 @@ Transmogrify helpers
 
 Various add-ons exist to make working with transmogrify easier:
 
-- `mr.migrator <https://pypi.python.org/pypi/mr.migrator>`_ is a way to easily lay pipelines
+- `mr.migrator <https://pypi.python.org/pypi/mr.migrator>`_ is a way to lay pipelines
 - `funnelweb <https://pypi.python.org/pypi/funnelweb>`_ helps to parse static sites, and crawl external sites
 - `parse2plone <https://pypi.python.org/pypi/parse2plone>`_ is meant to get HTML content from the file system into Plone
 

--- a/develop/plone/content/archetypes/archetypes_references.rst
+++ b/develop/plone/content/archetypes/archetypes_references.rst
@@ -40,7 +40,7 @@ Archetypes reference fields just store the UID (Universal Object Identifier)
 of an object providing the ``IReferenceable`` interface. Continuing with the
 example above, you will usually use the regular field API (getters/setters).
 
-You can get the UID of a referenceable object easily::
+Get the UID of a referenceable object::
 
     >>> areferenceableobject_uid = areferenceableobject.UID()
 

--- a/develop/plone/content/archetypes/storages.rst
+++ b/develop/plone/content/archetypes/storages.rst
@@ -24,7 +24,7 @@ persistent entity. A bucket usually holds a small number of items. Buckets
 are loaded on request and as needed compared to using native Python
 datatypes.
 
-It is safe to assume that you can fit few variables to one bucket easily.
+It is safe to assume that you can fit few variables to one bucket.
 
 You also might want to define ``ATFieldProperty`` accessor if you are using
 this storage.  This allows you to read the object value using standard

--- a/develop/plone/content/listing.rst
+++ b/develop/plone/content/listing.rst
@@ -654,10 +654,10 @@ Here is a no-warranty hack how to prevent ``folder_listing`` if needed::
 Complex folder listings and filtering
 ======================================
 
-The following example is for a very complex folder listing view.
+The following example is for a complex folder listing view.
+
 You can call view methods to returns the listed items themselves and render
-the HTML in another view --- this allows you to recycle this listing code
-easily.
+the HTML in another view --- this allows you to recycle this listing code.
 
 The view does the various sanity checks that normal Plone item listings do:
 

--- a/develop/plone/content/types.rst
+++ b/develop/plone/content/types.rst
@@ -181,8 +181,7 @@ Creating types by hand is not worth the trouble.
 Creating new content types through-the-web
 =============================================
 
-There exist solutions for non-programmers and Plone novices
-to create their content types more easily.
+There are solutions for non-programmers and Plone novices to create their content types.
 
 Dexterity
 ---------

--- a/develop/plone/i18n/internationalisation.rst
+++ b/develop/plone/i18n/internationalisation.rst
@@ -31,7 +31,7 @@ See also `zope.i18n on pypi <https://pypi.python.org/pypi/zope.i18n>`_
 * Translations are stored in the ``locales`` folder of your application.
   Example: ``locales/fi/LC_MESSAGES/your.app.po``
 
-* Has `zope.i18nmessageid <https://pypi.python.org/pypi/zope.i18nmessageid>`_ package, which provides a string-like class which allows storing the translation domain with translatable text strings easily.
+* Has `zope.i18nmessageid <https://pypi.python.org/pypi/zope.i18nmessageid>`_ package, which provides a string-like class which allows storing the translation domain with translatable text strings.
 
 * ``.po`` files must usually be manually converted to ``.mo`` binary files every time the translations are updated.  See :term:`i18ndude`. (It is also possible to set an environment variable to trigger recompilation of ``.mo`` files; see below.)
 

--- a/develop/plone/misc/slideshow.rst
+++ b/develop/plone/misc/slideshow.rst
@@ -405,7 +405,7 @@ ZCML
 AJAX full-size image loading for album views
 ----------------------------------------------
 
-Plone album views can be easily converted to pop-up image viewing with PipBox.
+Plone album views can be converted to pop-up image viewing with PipBox.
 
 Put the following to portal_properties / pipbox_properties
 

--- a/develop/plone/persistency/database.rst
+++ b/develop/plone/persistency/database.rst
@@ -85,8 +85,8 @@ This gives some benefits
 * The backend to perform queries is flexible - you
   can plug-in custom indexes
 
-* portal_catalog default catalog is used to all content items
-  to provide basic CMS functionality easily
+* portal_catalog default catalog is used for all content items
+  to provide basic CMS functionality
 
 * You can have optimized catalogs for specialized data (e.g. reference look-ups
   using reference_catalog)

--- a/develop/plone/security/selinux.rst
+++ b/develop/plone/security/selinux.rst
@@ -365,7 +365,7 @@ Easiest way to test the policy is to label for instance the Python executable as
     # chcon system_u:object_r:plonectl_t:s0 python2.7
     # setenforce Enforcing
 
-This can easily be refined into automated testing. Other forms such as Portlet inside running Plone process can also be used for testing.
+This can be refined into automated testing. Other forms such as Portlet inside running Plone process can also be used for testing.
 
 Deploying the policy
 ====================

--- a/develop/plone/serving/http_request_and_response.rst
+++ b/develop/plone/serving/http_request_and_response.rst
@@ -302,7 +302,7 @@ Request port
 
 It is possible to extract the Zope instance port from the request.  This is
 useful e.g. for debugging purposes if you have multiple ZEO front ends running,
-and you want to identify them easily::
+and you want to identify them::
 
     port = request.get("SERVER_PORT", None)
 
@@ -584,13 +584,13 @@ Below is an example how to install an event handler which checks in the site
 root for a TTW Python script and if such exist it asks it to provide a HTTP
 redirect.
 
-This behavior allows you to write site-wide redirects easily
+This behavior allows you to write site-wide redirects
 
 * In Python (thank god no Apache regular expressions)
 
 * Redirects can access Plone content items
 
-* You can easily have some redirects migrated from the old (non-Plone) sites
+* You can have some redirects migrated from the old (non-Plone) sites
 
 Add the event subscriber to ``configure.zcml``:
 

--- a/develop/plone/views/browserviews.rst
+++ b/develop/plone/views/browserviews.rst
@@ -655,7 +655,7 @@ To use the same template code several times you can either:
     referring to them outside templates is difficult.
 
     If you ever need to change the template language, or mix in other
-    template languages, you can do it much more easily when templates are a
+    template languages, you can do better when templates are a
     feature of a pure Python based view, and not vice versa.
 
 Here is an example of how to have a view snippet which can be used by

--- a/develop/plone/views/layers.rst
+++ b/develop/plone/views/layers.rst
@@ -4,8 +4,7 @@ Layers
 
 .. admonition:: Description
 
-    Layers allow you to easily enable and disable views and other site
-    functionality based on installed add-ons and themes.
+   Layers allow you to enable and disable views and other site functionality based on installed add-ons and themes.
 
 
 Introduction

--- a/manage/deploying/performance/ramcache.rst
+++ b/manage/deploying/performance/ramcache.rst
@@ -103,7 +103,7 @@ Example::
     # 2) The result cleaned HTML is cached in RAM
     #
     # We do not persistently want to store cleaned HTML,
-    # since our cleaner might be b0rked and we want to easily
+    # since our cleaner might be b0rked and we want to
     # regenerate cleaned HTML when needed.
     #
 
@@ -179,8 +179,8 @@ It takes optional backends which must be explicitly set::
             pas.ZCacheable_setManagerId(manager_id="RAMCache")
         getLDAPPlugin().ZCacheable_setManagerId(manager_id="RAMCache")
 
-The ``RAMCache`` above is per thread. You cannot clear this cache for all
-ZEO clients easily.
+The ``RAMCache`` above is per thread.
+Clearing this cache for all ZEO clients is hard.
 
 Some hints:
 

--- a/manage/installing/installing_addons.rst
+++ b/manage/installing/installing_addons.rst
@@ -106,7 +106,7 @@ As mentioned above, always make sure to test add-ons, and see if you have the ri
 
 It is **standard, and highly recommended practice** to pick specific versions of add-ons. This practice is called "pinning".
 
-If you don't *pin* a specific version, a run of ``bin/buildout`` might download a newer version of an add-on, that in turn might depend on newer other software. This can easily lead to breakage of your site.
+If you don't *pin* a specific version, a run of ``bin/buildout`` might download a newer version of an add-on, that in turn might depend on newer other software. This can lead to breakage of your site.
 
 Therefore, always put the specific version number of the add-on into the section of buildout.cfg called "versions", or into the separate file "versions.cfg" if your buildout has one.
 An example of version-pinning would be to have:
@@ -123,7 +123,7 @@ When :doc:`upgrading add-ons </manage/upgrading/addon_upgrade>` also don't just 
 Installing development version of add-on packages
 -------------------------------------------------
 
-If you need to use the latest development version of an add-on package you can easily get the source in your development installation using the buildout extension `mr.developer <https://pypi.python.org/pypi/mr.developer>`_.
+If you need to use the latest development version of an add-on package you can get the source in your development installation using the buildout extension `mr.developer <https://pypi.python.org/pypi/mr.developer>`_.
 
 'mr.developer' can install, or *checkout* from various places: github, gitlab, subversion, private repositories etcetera.
 You can pick specific tags and branches to checkout.

--- a/working-with-content/collaboration-and-workflow/advanced-control.rst
+++ b/working-with-content/collaboration-and-workflow/advanced-control.rst
@@ -73,7 +73,7 @@ The next field, *Include contained items*, is a check box for controlling whethe
 
 **This is an important check box**.
 
-It lets you easily change the availability of an entire section of a website.
+It lets you change the availability of an entire section of a website.
 For example, the "Documentation" folder could contain four subfolders, with images, files, and other content that has been kept *private* during the initial work to build up this content.
 All of it could be immediately made public -- it could be *published* -- by checking this box and checking *Publish* at the bottom before saving.
 

--- a/working-with-content/content-quality/content-quality-helpers.rst
+++ b/working-with-content/content-quality/content-quality-helpers.rst
@@ -24,7 +24,7 @@ Check your links
 ----------------
 
 - `collective.linkcheck <https://pypi.python.org/pypi/collective.linkcheck>`_ provides link validity checking and reporting.
-- although you may also want to keep this out of Plone itself, and run an external linkchecker regularly. `This Linkchecker <http://wummel.github.io/linkchecker/>`_ is open source, available for multiple platforms and can be easily scripted.
+- although you may also want to keep this out of Plone itself, and run an external linkchecker regularly. `This Linkchecker <http://wummel.github.io/linkchecker/>`_ is open source, available for multiple platforms and can be scripted.
 
 Better images
 --------------

--- a/working-with-content/introduction/user-accounts-and-roles.rst
+++ b/working-with-content/introduction/user-accounts-and-roles.rst
@@ -31,7 +31,8 @@ This is why this mode is called anonymous: anyone can do it just by surfing norm
 .. note::
 
     **Pro tip**: you can use two different browsers (like Firefox and Chrome), and *not*  log in with one of them.
-    That way you can easily compare how visitors will see your site, and you can spot content that is not yet published.
+
+    That way you can compare how visitors will see your site, and you can spot content that is not yet published.
 
 Note the presence of the *log in* link in the screen image below.
 If there is a *log in* link showing, you haven't logged in -- and you are surfing the web site anonymously, as seen in the following screen capture of a new Plone web site:

--- a/working-with-content/introduction/visual-design-of-plone.rst
+++ b/working-with-content/introduction/visual-design-of-plone.rst
@@ -48,10 +48,12 @@ At the bottom area (often known as "footer") it has links to social media, legal
 Nowadays, since the rise of mobile devices like tablets and smartphones, websites quite often look different depending on the screen size.
 On a smartphone, the navigation is often contracted into a single icon that expands when the user touches it.
 Also, the "left" and "right" areas may be shown after the "main" area when using a smartphone.
-This technique is known as *responsive design*, and can be easily implemented using Plone.
+
+This technique is known as *responsive design*, and can be implemented using Plone.
 The default theme for Plone 5 uses this method already.
 
 What does a Plone web site look like?
-Traditionally, the out-of-the-box look is like that shown at the top of this page, with
-header, menu, columns, and a footer.
+
+Traditionally, the out-of-the-box look is like that shown at the top of this page, with header, menu, columns, and a footer.
+
 But using the flexible "Diazo" theme engine of Plone, each aspect can be made to look any way the designer chooses, and can also be shown different depending on the device of the visitor.

--- a/working-with-content/using-collections/newstyle/introduction-to-collections.rst
+++ b/working-with-content/using-collections/newstyle/introduction-to-collections.rst
@@ -8,7 +8,7 @@ A **Collection** in Plone works much like a report or query does in a database.
 The idea is that you use a Collection to search your website based on a set of **Criteria** such as: content type (page, news item, image), the date it was published, or keywords contained in the title, description, or body.
 
 Let's say you have a large catalog of photos and maps on your website.
-You can easily display them all at once by creating a link to the folder they're stored in.
+You can display them all at once by creating a link to the folder they're stored in.
 You could even create different links for subfolders if you've organized things that way.
 However, if your images and maps were spread out over the site in many folders this would quickly become cumbersome.
 Also, there is no way with normal folders to display different content, from different parts of your site based on things like:

--- a/working-with-content/using-collections/oldstyle/introduction-to-collections.rst
+++ b/working-with-content/using-collections/oldstyle/introduction-to-collections.rst
@@ -8,7 +8,7 @@ A **Collection** in Plone works much like a report or query does in a database.
 The idea is that you use a Collection to search your website based on a set of **Criteria** such as: content type (page, news item, image), the date it was published, or keywords contained in the title, description, or body.
 
 Let's say you have a large catalog of photos and maps on your website.
-You can easily display them all at once by creating a link to the folder they're stored in.
+You can display them all at once by creating a link to the folder they're stored in.
 You could even create different links for subfolders if you've organized things that way.
 However, if your images and maps were spread out over the site in many folders this would quickly become cumbersome.
 Also, there is no way with normal folders to display different content, from different parts of your site based on things like:

--- a/working-with-content/using-collections/oldstyle/setting-the-sort-order.rst
+++ b/working-with-content/using-collections/oldstyle/setting-the-sort-order.rst
@@ -36,7 +36,7 @@ make the Collection very easy to browse for the site visitor.
 Sorting by State will display results grouped by the publishing state.
 Since there are only two States in the default configuration of Plone,
 there will only be Published and Private items. We can use this to
-separate all pages on our site and easily see what we have that is
+separate all pages on our site and see what we have that is
 public (Published) and what we are hiding from the public eye (Private).
 
 **Category**


### PR DESCRIPTION
Fixes: #805 

Changes proposed in this pull request:

- Removal of the word 'easily'

- Adjust sentences 




