### PR TITLE
Updated add-ons/downloads link

### DIFF
--- a/_templates/doormat.html
+++ b/_templates/doormat.html
@@ -27,8 +27,8 @@
       <div class="col-xs-6 col-sm-3">
       Download:
         <ul class="list-unstyled">
-          <li><a href="https://plone.org/products/plone">Plone</a></li>
-          <li><a href="https://plone.org/products">Plone add-ons</a></li>
+          <li><a href="https://plone.org/download">Plone</a></li>
+          <li><a href="https://plone.org/download/add-ons">Plone add-ons</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Fixes: #

Improves:

Changes proposed in this pull request:

- Downloads link was linking to https://plone.org/products/plone, which redirects to https://plone.org/download. Updated to a direct link, since it's faster.

- Addons link was pointing to downloads page, so I updated it to the direct page for add-ons at https://plone.org/download/add-ons.