### PR TITLE
use PyPI link for source of zope.app.cache

### DIFF
--- a/manage/deploying/performance/ramcache.rst
+++ b/manage/deploying/performance/ramcache.rst
@@ -219,4 +219,4 @@ Other resources
 
 * `plone.memoize source code <https://github.com/plone/plone.memoize/blob/master/plone/memoize/>`_.
 
-* `zope.app.cache source code <http://svn.zope.org/zope.app.cache/trunk/src/zope/app/cache/>`_
+* `zope.app.cache source code <https://pypi.python.org/pypi/zope.app.cache>`_


### PR DESCRIPTION
- No more source code on svn.zope.org, and redirect is a 404. Maybe there is a better link out of this list?
https://github.com/zopefoundation?language=&page=2&q=zope.app&type=&utf8=%E2%9C%93