### PR TITLE
Move minimal buildout docs out of requirements

### DIFF
--- a/manage/installing/index.rst
+++ b/manage/installing/index.rst
@@ -6,5 +6,6 @@ Installing Plone
 
    requirements
    installation
+   installation_minimal_buildout
    installing_addons
    hotfixes

--- a/manage/installing/installation_minimal_buildout.rst
+++ b/manage/installing/installation_minimal_buildout.rst
@@ -50,7 +50,7 @@ Run buildout:
 
 .. code-block:: shell
 
-   /bin/buildout
+   ./bin/buildout
 
 This will start a long download and build process.
 
@@ -60,7 +60,7 @@ After it finished you can start Plone in foreground-mode with:
 
 .. code-block:: shell
 
-   bin/instance fg
+   ./bin/instance fg
 
 You can stop it with ``ctrl + c``.
 
@@ -68,9 +68,9 @@ Start and stop this Plone-instance in production-mode like this;
 
 .. code-block:: shell
 
-   bin/instance start
+   ./bin/instance start
 
-   bin/instance stop
+   ./bin/instance stop
 
 Plone will run on port 8080 you can access your install via http://localhost:8080.
 

--- a/manage/installing/installation_minimal_buildout.rst
+++ b/manage/installing/installation_minimal_buildout.rst
@@ -2,16 +2,21 @@
 Install Plone Using A Minimal Buildout
 ======================================
 
-With complete requirements in place, a Plone install may be created with a few steps.
+.. note ::
 
-Create a directory called Plone-5 and enter it:
+   This example is adequate for a quick evaluation.
+
+   **Do not use it in production !**
+
+
+Create a directory called `Plone-5` and enter it:
 
 .. code-block:: shell
 
    mkdir Plone-5
    cd Plone-5
 
-Run the steps to create a virtual python environment (virtualenv) and install zc.buildout:
+Create a virtual python environment (`virtualenv <https://virtualenv.pypa.io/en/stable/>`_) and install `zc.buildout <https://pypi.python.org/pypi/zc.buildout>`_:
 
 .. code-block:: shell
 
@@ -47,9 +52,9 @@ Run buildout:
 
    /bin/buildout
 
-This will start a long download and build process ...
+This will start a long download and build process.
 
-Errors like SyntaxError: ("'return' outside function"..." may be ignored.
+You can ignore Errors like ``SyntaxError: ("'return' outside function"..."``.
 
 After it finished you can start Plone in foreground-mode with:
 
@@ -57,7 +62,7 @@ After it finished you can start Plone in foreground-mode with:
 
    bin/instance fg
 
-You can stop it with ctrl + c.
+You can stop it with ``ctrl + c``.
 
 Start and stop this Plone-instance in production-mode like this;
 
@@ -67,7 +72,6 @@ Start and stop this Plone-instance in production-mode like this;
 
    bin/instance stop
 
-Plone will run on port 8080 and can be accessed via http://localhost:8080. Use login id "admin" and password "admin" for initial login so you can create a site.
+Plone will run on port 8080 you can access your install via http://localhost:8080.
 
-This build would be adequate for a quick evaluation installation. For a production or development installation, use one of Plone's installers.
-
+Use login id "admin" and password "admin" for initial login so you can create a site.

--- a/manage/installing/installation_minimal_buildout.rst
+++ b/manage/installing/installation_minimal_buildout.rst
@@ -1,0 +1,73 @@
+======================================
+Install Plone Using A Minimal Buildout
+======================================
+
+With complete requirements in place, a Plone install may be created with a few steps.
+
+Create a directory called Plone-5 and enter it:
+
+.. code-block:: shell
+
+   mkdir Plone-5
+   cd Plone-5
+
+Run the steps to create a virtual python environment (virtualenv) and install zc.buildout:
+
+.. code-block:: shell
+
+   virtualenv-2.7 zinstance
+   cd zinstance
+   bin/pip install zc.buildout
+
+Create a buildout.cfg file:
+
+.. code-block:: ini
+
+  echo """
+  [buildout]
+  extends =
+      http://dist.plone.org/release/5-latest/versions.cfg
+
+  parts =
+      instance
+
+  [instance]
+  recipe = plone.recipe.zope2instance
+  user = admin:admin
+  http-address = 8080
+  eggs =
+      Plone
+      Pillow
+
+  """ > buildout.cfg
+
+Run buildout:
+
+.. code-block:: shell
+
+   /bin/buildout
+
+This will start a long download and build process ...
+
+Errors like SyntaxError: ("'return' outside function"..." may be ignored.
+
+After it finished you can start Plone in foreground-mode with:
+
+.. code-block:: shell
+
+   bin/instance fg
+
+You can stop it with ctrl + c.
+
+Start and stop this Plone-instance in production-mode like this;
+
+.. code-block:: shell
+
+   bin/instance start
+
+   bin/instance stop
+
+Plone will run on port 8080 and can be accessed via http://localhost:8080. Use login id "admin" and password "admin" for initial login so you can create a site.
+
+This build would be adequate for a quick evaluation installation. For a production or development installation, use one of Plone's installers.
+


### PR DESCRIPTION
Fixes: #807 

Improves: Moves minimal buildout section out of requirements and place it under installation 

Changes proposed in this pull request:

- Move minimal buildout part

- Improve wording [less passive voice]

- Improve reST

This PR still **not** fixes #879 but at least improves the docs till we resolve #879.


