### PR TITLE
WIP: remove bootstrap

### DIFF
--- a/develop/addons/schema-driven-forms/creating-a-simple-form/testing-the-form.rst
+++ b/develop/addons/schema-driven-forms/creating-a-simple-form/testing-the-form.rst
@@ -69,7 +69,7 @@ buildout. It should look just similiar to the packages buildout.
     [code-analysis]
     recipe = plone.recipe.codeanalysis
     directory = ${buildout:directory}/src/example
-    flake8-exclude = bootstrap.py,bootstrap-buildout.py,docs,*.egg.,omelette
+    flake8-exclude = docs,*.egg.,omelette
     flake8-max-complexity = 15
     flake8-extensions =
         flake8-blind-except

--- a/develop/plone/getstarted/python.rst
+++ b/develop/plone/getstarted/python.rst
@@ -29,3 +29,59 @@ Python tutorials and online classes
 * `Dive into Python book <http://www.diveintopython.net/toc/index.html>`_
 
 * `Python at codeacademy.org <http://www.codecademy.com/#!/exercises/0>`_
+
+Virtualenv
+==========
+``virtualenv`` is a tool that allows the creation of virtual environments.
+
+A virtual environment is a way to isolate a python installation from other installations as well as the system wide python.
+
+There a plenty of reasons one wants an isolated environment:
+
+- to be able to have different python installations for each project (a Zope 4 project on python 3 and a Plone 5 project on python 2)
+- to be able to install dependencies of each project without installing them system wide
+- to not have to need administrator permissions to install project dependencies
+- to be able to make the environment repeatable (this is key for any serious testing/Continuous Integration effort)
+
+It is so important,
+that since Python 3.3 is a standard module: `venv <https://docs.python.org/3/library/venv.html>`_,
+see the `PEP405 <https://www.python.org/dev/peps/pep-0405/>`_ that lead to the ``venv`` module for all the details and rationale.
+
+Install virtualenv
+------------------
+If you plan to use a virtual environment on a Python 3.3+ project you are done!
+You don't need to install *anything* in order to use virtual environments.
+
+If you are working on a project prior to Python 3.3,
+you need to install `virtualenv <https://pypi.python.org/pypi/virtualenv>`_.
+Fortunately, either your system (especially on Linux distributions) has already system packages that install it system wide,
+or you can install it with `pip <https://pypi.python.org/pypi/pip>`_.
+
+Use virtualenv
+--------------
+To create a virtual environment on python 3.3+, do the following:
+
+.. code-block:: shell
+
+    python3 -m venv my-environment
+
+If you use the ``virtualenv`` python package:
+
+.. code-block:: shell
+
+    virtualenv my-environment
+
+Once the folder is created you can enter it and start using it:
+
+.. code-block:: shell
+
+    cd my-environment
+    source bin/activate
+    pip install zc.buildout setuptools
+    *use*
+    deactivate
+
+.. note::
+
+   Some developers do not *activate* the virtual environment and rather call directly the tools on the ``bin`` folder.
+   This has the advantage that one does not need to activate and deactivate the environment every time.

--- a/manage/troubleshooting/buildout.rst
+++ b/manage/troubleshooting/buildout.rst
@@ -341,6 +341,10 @@ Solution: update the ``zc.buildout`` installed in your system Python:
 
     easy_install -U zc.buildout
 
+.. note::
+
+   Or better, use virtualenv! **TODO LINK TO THE VIRTUALENV SECTION**
+
 An error occurred when trying to install lxml - error: Setup script exited with error: command 'gcc' failed with exit status 1
 ==============================================================================================================================
 
@@ -411,6 +415,9 @@ If you get::
 
 Rerun ``bootstrap.py`` with the correct Python interpreter.
 
+.. note::
+
+   Or better, use virtualenv! **TODO LINK TO THE VIRTUALENV SECTION**
 
 Error: Picked: <some.package> = <some.version>
 ==============================================
@@ -479,7 +486,9 @@ uses this version or above::
 
        sudo /srv/plone/python/python-2.7/bin/easy_install -U Distribute
 
+.. note::
 
+   Or better, use virtualenv! **TODO LINK TO THE VIRTUALENV SECTION**
 
 UnboundLocalError: local variable 'clients' referenced before assignment
 ==========================================================================

--- a/manage/troubleshooting/exceptions.rst
+++ b/manage/troubleshooting/exceptions.rst
@@ -990,6 +990,9 @@ Then as the non-root re-bootstrap the buildout using non-system wide Python::
 
 ... and after this it should no longer pull the bad system lxml.
 
+.. note::
+
+   Or better, use virtualenv! **TODO LINK TO THE VIRTUALENV SECTION**
 
 ImportError: No module named pkgutil
 ------------------------------------


### PR DESCRIPTION
*this is part of [PLIP 2001 get rid of bootstrap](https://github.com/plone/Products.CMFPlone/issues/2001) please do not merge.*

Changes proposed in this pull request:
- [ ] explain what virtualenvs are and how use them
- [ ] porting guide from bootstrap.py to virtualenv
- [ ] remove/update bootstrap references to virtualenv
- [ ] update external references included on the docs
  - [ ] externals
  - [ ] trainging.plone.org
  - [ ] *plone.org?*
  - *anything else?*

I would like some early feedback from @plone/documentation-team for:
- where to put the virtualenv explanation
- where to put the porting guide
- where to find the external documentation to check if it needs updates