### PR TITLE
Improve Update Guide

### DIFF
--- a/manage/upgrading/preparations.rst
+++ b/manage/upgrading/preparations.rst
@@ -7,7 +7,7 @@ Preparations
    Things to do before you migrate Plone.
 
 
-Gather information
+Gather Information
 ==================
 
 - Read the "What's new in..." for your relevant Plone version, and read the release notes.
@@ -45,7 +45,7 @@ Gather information
 
     - These files are important because they may contain important last minute information and might be more specific than the relevant sections of this reference manual.
 
-Back up your Plone site
+Back Up Your Plone Site
 =======================
 
 .. note::
@@ -54,7 +54,7 @@ Back up your Plone site
 
 You will find a :doc:`how-to on backing up your Plone site here </manage/deploying/backup>`.
 
-Setup a test environment to rehearse the upgrade
+Setup A Test Environment To Rehearse The Upgrade
 ================================================
 
 .. note::

--- a/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
+++ b/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
@@ -1,5 +1,5 @@
 ==========================
-Upgrading Plone 4.x to 5.0
+Upgrading Plone 4.x To 5.0
 ==========================
 
 
@@ -12,16 +12,17 @@ Upgrading Plone 4.x to 5.0
    If you want to upgrade add-ons to Plone 5, also see: ../../../develop/addons/upgrade_to_50.rst
 
 
-General information
+General Information
 ===================
 
 - Before you upgrade read :doc:`../into.rst` and :doc:`../preparations.rst`.
-- Always upgrade from the latest version of 4.x to the latest version of 5.x (at the time of writing 4.3.7 to 5.0.2). This will resolve many migration-specific issues.
+- Always upgrade from the latest version of 4.x to the latest version of 5.x (at the time of writing 4.3.7 to 5.0.2).
+  This will resolve many migration-specific issues.
 - If you have problems don't be afraid to ask for help on http://community.plone.org
 - There is a video of a talk "How to upgrade sites to Plone 5": https://youtu.be/bQ-IpO-7F00?t=1m17s (slides: http://de.slideshare.net/derschmock/upgrade-to-plone-5)
 
 
-Changes due to implemented PLIPS
+Changes Due To Implemented PLIPS
 ================================
 
 PLIPs are PLone Improvement Proposals.
@@ -29,31 +30,40 @@ These are about larger changes to Plone,
 discussed beforehand by the community.
 
 
-PLIP 13350 "Define extra member properties TTW"
+PLIP 13350 "Define Extra Member Properties TTW"
 -----------------------------------------------
 
-In Plone 5, the custom fields displayed in the user profile form and the registration form are managed by `plone.schemaeditor`.
-They are dynamically editable from the Plone control panel, and can be imported from a Generic Setup profile file named `userschema.xml`.
+In Plone 5, the custom fields displayed in the user profile form and the registration form are managed
+by `plone.schemaeditor`.
+
+They are dynamically editable from the Plone control panel,
+and can be imported from a Generic Setup profile file named `userschema.xml`.
 
 If you have some custom member properties in your Plone site, be aware that:
 
-- extra attributes defined in `memberdata_properties.xml` will be preserved, but they will not be automatically shown in the user profile form or the registration form,
-- if you have implemented some custom forms in order to display your custom member attributes, they will not work anymore as `plone.app.users` is now based on `z3c.form`.
+- extra attributes defined in `memberdata_properties.xml` will be preserved,
+  but they will not be automatically shown in the user profile form or the registration form,
+- if you have implemented some custom forms in order to display your custom member attributes,
+  they will not work anymore as `plone.app.users` is now based on `z3c.form`.
   You can replace them by declaring their schema in `userschema.xml`.
 
 .. note::
 
-    When a custom field is defined in `userschema.xml`, its corresponding attribute is automatically created in the `portal_memberdata` tool, so there is no need to declare it in `memberdata_properties.xml`.
+    When a custom field is defined in `userschema.xml`,
+    its corresponding attribute is automatically created in the `portal_memberdata` tool,
+    so there is no need to declare it in `memberdata_properties.xml`.
+    
     `memberdata_properties.xml` will only handled attributes that are not related to the user profile form or the registration form.
 
 
-PLIP 13419 "Improvements for user ids and login names"
+PLIP 13419 "Improvements For User Ids And Login Names"
 ------------------------------------------------------
 
 Since Plone 4.0 you could switch to using email as login in the security control panel.
 In Plone 5.0 some related improvements were made.
 When you are already using email as login,
 during the Plone 5.0 migration the login names will be transformed to lowercase.
+
 When the email addresses are not unique,
 for example you have both ``joe@example.org`` and ``JOE@example.org``,
 the migration will *fail*.
@@ -62,16 +72,17 @@ Best is to fix this in your site in Plone 4, by changing email addresses or remo
 When there are only a few users, you can do this manually.
 To assist you in sites with many users, in Plone 4.1 and higher,
 you can add the `collective.emaillogin4 <https://pypi.python.org/pypi/collective.emaillogin4>`_ package to the eggs of your Plone instance.
+
 With that package, even without installing it in the add-ons control panel,
 you can call the ``@@migrate-to-emaillogin`` page to look for duplicate email addresses.
 
 .. note::
 
-  This PLIP basically integrates the ``collective.emaillogin4`` package in Plone 5.
+   This PLIP basically integrates the ``collective.emaillogin4`` package in Plone 5.
 
 
 
-Other PLIP changes
+Other PLIP Changes
 ------------------
 
 PLIPs that resulted in changes that will have to be documented in this upgrade-guide.
@@ -101,31 +112,31 @@ Linkintegrity in Plone 5
 
 
 
-security setting changes
+Security Setting Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 complex, look betas.py **TODO**
 
-mail setting changes
+Mail Setting Changes
 ~~~~~~~~~~~~~~~~~~~~
 
-markup setting changes
+Markup Setting Changes
 ~~~~~~~~~~~~~~~~~~~~~~
 
-user_and_group setting changes
+User And Group Setting Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-social media changes
+Social Media Changes
 ~~~~~~~~~~~~~~~~~~~~
 
-imaging changes
+Imaging Changes
 ~~~~~~~~~~~~~~~
 
-login setting changes
+Login Setting Changes
 ~~~~~~~~~~~~~~~~~~~~~
 
 
-Changed imports and functions
+Changed Imports And Functions
 =============================
 
 
@@ -207,34 +218,47 @@ Resource Registry
 
 Plone 5 introduces some new concepts, for some, with working with JavaScript in Plone.
 Plone 5 utilizes Asynchronous Module Definition (AMD) with `requirejs <http://requirejs.org/>`_.
+
 We chose AMD over other module loading implementations(like commonjs) because AMD can be used in non-compiled form in the browser.
+
 This way, someone can click "development mode" in the resource registry control panel and work with the non-compiled JavaScript files directly.
 
 Getting back on point, much of Plone's JavaScript was or still is using JavaScript in a non-AMD form.
-Scripts that expect JavaScript dependency scripts and objects to be globally available and not loaded synchronously will have a difficult time figuring out what is going on when upgrading to Plone 5.
+Scripts that expect JavaScript dependency scripts and objects to be globally available
+and not loaded synchronously will have a difficult time figuring out what is going on when upgrading to Plone 5.
 
-There are two scenarios where this will happen that we'll tackle in this post. 1) You have JavaScript registered in portal_javascripts that are not AMD compatible. 2) You have JavaScript included in the head tag of your theme and/or specific page templates that are not AMD compatible.
+There are two scenarios where this will happen that we'll tackle in this post.
+- 1) You have JavaScript registered in portal_javascripts that are not AMD compatible.
+- 2) You have JavaScript included in the head tag of your theme and/or specific page templates that are not AMD compatible.
 
 
-1) Working with deprecated portal_javascripts
+Working With Deprecated Portal_javascripts
 ---------------------------------------------
 
 The deprecated resource registries(and portal_javascripts) has no concept of dependency management.
-It simply allowed you to specify an order in which JavaScript files should be included on your site.
+It allowed you to specify an order in which JavaScript files should be included on your site.
+
 It also would combined and minify them for you in deployment mode.
 
-Registration changes
+Registration Changes
 ~~~~~~~~~~~~~~~~~~~~
 
 Prior to Plone 5, JavaScript files were added to the registry by using a `Generic Setup Profile <http://docs.plone.org/develop/addons/components/genericsetup.html>`_ and including a jsregistry.xml file to it.
+
 This would add your JavaScript to the registry, with some options and potentially set ordering.
 
-In Plone 5.0, Plone will still recognize these jsregistry.xml files. Plone tries to provide a shim for them. It does this by adding all jsregistry.xml JavaScripts into the "plone-legacy" Resource Registry bundle. This bundle includes a global jQuery object and includes the resources in sequential order after it.
+In Plone 5.0, Plone will still recognize these jsregistry.xml files.
+Plone tries to provide a shim for them.
+It does this by adding all jsregistry.xml JavaScripts into the "plone-legacy" Resource Registry bundle.
 
-However, you should consider at least migrating your resources as described in https://github.com/collective/example.p4p5 to gain control over your dependencies or if you want to keep backward compatibility to older Plone versions in your Add-ons.
+This bundle includes a global jQuery object and includes the resources in sequential order after it.
+
+However, you should consider at least migrating your resources as described
+in https://github.com/collective/example.p4p5 to gain control over your dependencies or
+if you want to keep backward compatibility to older Plone versions in your Add-ons.
 
 
-Old style jsregistry.xml
+Old Style jsregistry.xml
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 An old style Resource Registry would look like this:
@@ -250,9 +274,10 @@ An old style Resource Registry would look like this:
     </object>
 
 
-To migrate this to Plone 5, resource registrations are all done in the `Configuration Registry <https://pypi.python.org/pypi/plone.app.registry>`_.
+To migrate this to Plone 5, resource registrations are all done in the
+`Configuration Registry <https://pypi.python.org/pypi/plone.app.registry>`_.
 
-New style with registry.xml
+New Style With registry.xml
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The new registration will look something like:
@@ -274,7 +299,9 @@ This is not necessary -- I'm just giving an example that this script needs a glo
 This alone will not get your JavaScript included however.
 In order to modernize our JavaScript stack, Plone needed to make some changes with how it included JavaScript.
 All we've done so far is define a resource.
-In order for a resource to be included, it needs to be part of a bundle. A bundle defines a set of resources that should be compiled together and distributed to the browser.
+
+For a resource to be included, it needs to be part of a bundle.
+A bundle defines a set of resources that should be compiled together and distributed to the browser.
 
 You either need to add your resource to an existing bundle or create your own bundle.
 
@@ -296,26 +323,37 @@ One important aspect here is the "jscompilation" settings.
 This defines the compiled resource used in production mode.
 
 
-But, it's a bit more work
+But, It's A Bit More Work
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Yes, we know. We tried very hard to figure out the easiest way to modernize Plone's JavaScript development stack.
 The old, sequential inclusion is not useful these days.
 
 That being said, adding resources, bundles and compiling them can all be done Through The Web(TTW) in the new Resource Registries configuration panel.
-That way you can turn on development mode, compile your resources and then copy that compiled version into your package for distribution and not need to know any newfangled nodejs technologies like grunt, gulp, bower, npm, etc.
+That way you can turn on development mode, compile your resources and then copy that
+compiled version into your package for distribution and not need to know any newfangled
+nodejs technologies like grunt, gulp, bower, npm, etc.
 
 
-Updating non-AMD scripts
+Updating Non-AMD Scripts
 ------------------------
 
-If you are not including your JavaScript in the Resource Registries and just need it to work alongside Plone's JavaScript because you're manually including the JavaScript files in one way or another(page templates, themes), there are a number of techniques available to read on the web that describe how to make your scripts conditionally work with AMD.
+If you are not including your JavaScript in the Resource Registries and
+need it to work alongside Plone's JavaScript because you're manually including the JavaScript
+files in one way or another(page templates, themes), there are a number of techniques available
+to read on the web that describe how to make your scripts conditionally work with AMD.
 
 For the sake of this post, I will describe one technique used in Plone core to fix the JavaScript.
-The change we'll be investigating can be seen with `in a commit to plone.app.registry <https://github.com/plone/plone.app.registry/commit/ad904f2d55ea6e45bb983f1fcc12ead7a191f50a>`_. plone.app.registry has a control panel that allows some Ajax searching and modals for editing settings.
 
-To utilize the dependency management that AMD provides and have the JavaScript depend on jQuery, we can wrap the script in an AMD `require` function.
-This function allows you to define a set of dependencies and a function that takes as arguments, those dependencies you defined. After the dependencies are loaded, the function you defined is called.
+The change we'll be investigating can be seen with `in a commit to plone.app.registry <https://github.com/plone/plone.app.registry/commit/ad904f2d55ea6e45bb983f1fcc12ead7a191f50a>`_.
+
+plone.app.registry has a control panel that allows some Ajax searching and modals for editing settings.
+
+To utilize the dependency management that AMD provides and have the JavaScript depend on jQuery,
+we can wrap the script in an AMD `require` function.
+
+This function allows you to define a set of dependencies and a function that takes as arguments,
+those dependencies you defined. After the dependencies are loaded, the function you defined is called.
 
 Example:
 
@@ -332,11 +370,15 @@ Example:
     });
 
 Here, the two dependencies we have are jQuery and the pattern registry.
-I will not get into the pattern registry as it's off topic for this discussion--it is basically a registry of JavaScript components.
+I will not get into the pattern registry as it's off topic for this discussion
+--it is basically a registry of JavaScript components.
+
 The necessity for using it here is with Ajax calls and binding new DOM elements dynamically added to the page.
 
 Additionally, above this `require` call, I provide some backward compatible code that you can inspect.
-It's not necessary in this case but I added it to show how someone could make their script work when requirejs was available and when it was not.
+
+It's not necessary in this case but I added it to show how someone could make
+their script work when requirejs was available and when it was not.
 
 
 Caveats
@@ -345,17 +387,20 @@ Caveats
 Compilation
 ~~~~~~~~~~~
 
-Prior to Plone 5, when a resource was changed or added to the JavaScript registry, the registry would automatically re-compile all your JavaScript files.
+Prior to Plone 5, when a resource was changed or added to the JavaScript registry,
+the registry would automatically re-compile all your JavaScript files.
 
 In switching to AMD, the compile step is much more resource intensive.
 It takes so long, there is no way we could do this real-time.
 Additionally, it can not be done in Python.
 
-When changes are made to existing bundles, re-compilation will need to be done TTW in the Resource Registries control panel.
+When changes are made to existing bundles, re-compilation will need to be done TTW (Trough-The-Web)
+in the Resource Registries control panel.
+
 There is a build button next to each bundle.
 For advanced users, compilation can be done using a tool like grunt in your development environment.
 
-Conditional resources
+Conditional Resources
 ~~~~~~~~~~~~~~~~~~~~~
 
 In Plone 5, individual resources can not be registered conditionally to certain page.
@@ -386,7 +431,8 @@ In Plone 5 it’s recommended to instead use the new Python methods you can find
 
 This is better than always loading a resource or bundle for your whole site.
 
-Only bundles can be conditionally included. If you have a resource that needs to be conditionally included, it will likely need its own bundle.
+Only bundles can be conditionally included.
+If you have a resource that needs to be conditionally included, it will likely need its own bundle.
 
 
 Control Panel
@@ -395,13 +441,25 @@ Control Panel
 In Plone 4.x, the Plone configuration settings have been stored as portal properties spread across the Management Interface.
 In Plone 5, those settings are all stored as plone.app.registry entries in registry.xml.
 
-There are now sections in the control panel, this can be set from the controlpanel.xml. See the current definitions for more information.
+There are now sections in the control panel, this can be set from the controlpanel.xml.
+See the current definitions for more information.
 
-The display of icons for control panels is now controlled by css.  The name of the control panel is normalized into a css class, which is applied to the link in the main layout of all control panels.  For example, if the “appId” of your control panel (as set in controlpanel.xml in your install profile) is “MyPackage” then the css class that will be generated is “.icon-controlpanel-MyPackage”. In order to have an icon for your control panel you must make sure that a css rule exists for that generated css class.  An example might be::
+The display of icons for control panels is now controlled by css.
+The name of the control panel is normalized into a css class, which is applied to the link in the main layout of all control panels.
+
+For example, if the “appId” of your control panel (as set in controlpanel.xml in your install profile)
+is “MyPackage” then the css class that will be generated is “.icon-controlpanel-MyPackage”.
+
+To have an icon for your control panel you must make sure that a css rule exists for that generated css class.
+
+An example might be
+
+.. code-block:: css
 
     .icon-controlpanel-MyPackage:before { content: ‘\e844’; }
 
-The value you use for this css rule should identify one of the fontello icons included in Plone, or a font-based icon provided by your package itself.
+The value you use for this css rule should identify one of the fontello icons included in Plone,
+or a font-based icon provided by your package itself.
 
 It is not possible at this time to set an icon for your add-on package control panels without including css in your package.
 
@@ -416,13 +474,17 @@ site properties allowed direct attribute access, so you could access the availab
 
     ptools.site_properties.available editors
 
-Now you can access the property via get_registry_record()::
+Now you can access the property via get_registry_record()
+
+.. code-block:: python
 
     >>> from plone import api
     >>> api.portal.get_registry_record('plone.available_editors')
 
 The keys mostly the same, they are only prefixed with `plone.` now.
-Normally, you do not modify or access these records. Instead you change the settings in your genericsetup profile in the file `propertiestool.xml`
+Normally, you do not modify or access these records.
+
+Instead you change the settings in your genericsetup profile in the file `propertiestool.xml`
 
 +--------------------+-----------------------------------+-----------------------------------------+
 | Old Property Sheet | Old Key                           | New Property                            |
@@ -564,17 +626,25 @@ disable_folder_sections
 This property has been removed and the logic is different.
 You can influence the portal tab generation with the property `plone.generate_tabs`
 This controls, if the tabs are generated from the content in the root folder.
+
 In addition, you can control if non folders will create entries or not with the property `plone.nonfolderish_tabs`.
 If you want to disable_folder_sections, you will want to set `plone.generate_tabs` to false.
 
 Generic Setup
 -------------
 
-All settings for control panels are stored in the registry.xml Generic Setup file. This file can be exported through the Management Interface.
-Go to the Plone Site Setup, choose "Management Interface" from the "Advanced" section.
-Click on "portal_setup". Go to the "export" tab.
-Choose the "Export the configuration registry schemata" check-box and click the "Export selected steps" button.
-The registry.xml file will contain entries like this::
+All settings for control panels are stored in the registry.xml Generic Setup file.
+This file can be exported through the Management Interface.
+
+Go to the Plone Site Setup, choose :guilabel:`Management Interface` from the "Advanced" section.
+Click on :guilabel:`portal_setup`.
+Go to the "export" tab.
+Choose the :guilabel:`Export the configuration registry schemata` check-box and
+click the :guilabel:`Export selected steps` button.
+
+The registry.xml file will contain entries like this
+
+.. code-block:: xml
 
   <record name="plone.available_editors"
           interface="Products.CMFPlone.interfaces.controlpanel.IEditingSchema" field="available_editors">
@@ -590,7 +660,9 @@ The registry.xml file will contain entries like this::
     </value>
   </record>
 
-Drop the settings you want to change into registry.xml in you Generic Setup profile folder. Re-install your add-on product and the settings will be available.
+Drop the settings you want to change into registry.xml in you Generic Setup profile folder.
+
+Re-install your add-on product and the settings will be available.
 
 
 Python Code
@@ -598,40 +670,52 @@ Python Code
 
 All Generic Setup settings can be looked up with Python code.
 
-First we lookup the registry utility::
+First we lookup the registry utility
 
-  >>> from zope.component import getUtility
-  >>> from plone.registry.interfaces import IRegistry
-  >>> registry = getUtility(IRegistry)
+.. code-block:: python
+
+   >>> from zope.component import getUtility
+   >>> from plone.registry.interfaces import IRegistry
+   >>> registry = getUtility(IRegistry)
 
 Now we use the schema 'ISearchSchema' to lookup for a RecordProxy object with
-all fields::
+all fields
 
-  >>> from Products.CMFPlone.interfaces import ISearchSchema
-  >>> search_settings = registry.forInterface(ISearchSchema, prefix='plone')
+.. code-block:: python
 
-Now we an get and set all fields of the schema above like::
+   >>> from Products.CMFPlone.interfaces import ISearchSchema
+   >>> search_settings = registry.forInterface(ISearchSchema, prefix='plone')
 
-  >>> search_settings.enable_livesearch
-  True
+Now we an get and set all fields of the schema above like
 
-If you want to change a setting, change the attribute::
+.. code-block:: python
 
-  >>> search_settings.enable_livesearch = False
+   >>> search_settings.enable_livesearch
+   True
 
-Now the enable_livesearch should disabled::
+If you want to change a setting, change the attribute
 
-  >>> search_settings.enable_livesearch
-  False
+.. code-block:: python
+
+   >>> search_settings.enable_livesearch = False
+
+Now the enable_livesearch should disabled
+
+.. code-block:: python
+
+   >>> search_settings.enable_livesearch
+   False
 
 
 Editing Control Panel
 ---------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import IEditingSchema
-  >>> editing_settings = registry.forInterface(IEditingSchema, prefix='plone')
+.. code-block:: python
+
+   >>> from Products.CMFPlone.interfaces import IEditingSchema
+   >>> editing_settings = registry.forInterface(IEditingSchema, prefix='plone')
 
   >>> editing_settings.default_editor
   u'TinyMCE'
@@ -651,8 +735,14 @@ Language Control Panel
 
 All settings were managed with the tool `portal_languages` and with the GenericSetup file portal_languages.xml.
 Now these attributes are managed with Plone properties.
-As Plone 5 has full migration during an upgrade, please perform the upgrade and export the registry settings in GenericSetup to get the right settings.
-If you access attributes directly in your code, you must change your accessors. You know already how to get attributes from the `portal_languages` tool. The new attributes can be accessed via plone.api as described above.
+
+As Plone 5 has full migration during an upgrade, please perform the upgrade and
+export the registry settings in GenericSetup to get the right settings.
+
+If you access attributes directly in your code, you must change your accessors.
+You know already how to get attributes from the `portal_languages` tool.
+
+The new attributes can be accessed via plone.api as described above.
 
 +-----------------------------------------------------------------------------------+-----------------------------------+
 | old attribute                                                                     | new attribute                     |
@@ -684,21 +774,29 @@ If you access attributes directly in your code, you must change your accessors. 
 | portal_languages.always_show_selector                                             | plone.always_show_selector        |
 +-----------------------------------------------------------------------------------+-----------------------------------+
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import ILanguageSchema
-  >>> language_settings = registry.forInterface(ILanguageSchema, prefix='plone')
+.. code-block:: python
 
-  >>> language_settings.available_languages
-  ['en']
+   >>> from Products.CMFPlone.interfaces import ILanguageSchema
+   >>> language_settings = registry.forInterface(ILanguageSchema, prefix='plone')
+
+   >>> language_settings.available_languages
+   ['en']
 
 Mail Control Panel
 ------------------
 
 All settings were managed with the tool `MailHost` and with the GenericSetup file portal_languages.xml.
 Now these attributes are managed with Plone properties.
-As Plone 5 has full migration during an upgrade, please perform the upgrade and export the registry settings in GenericSetup to get the right settings.
-If you access attributes directly in your code, you must change your accessors. You know already how to get attributes from the `portal_languages` tool. The new attributes can be accessed via plone.api as described above.
+
+As Plone 5 has full migration during an upgrade,
+please perform the upgrade and export the registry settings in GenericSetup to get the right settings.
+
+If you access attributes directly in your code, you must change your accessors.
+
+You know already how to get attributes from the `portal_languages` tool.
+The new attributes can be accessed via plone.api as described above.
 
 +-----------------------------+--------------------------+
 | old attribute               | new attribute            |
@@ -720,131 +818,147 @@ If you access attributes directly in your code, you must change your accessors. 
 Maintenance Control Panel
 -------------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import IMaintenanceSchema
-  >>> maintenance_settings = registry.forInterface(IMaintenanceSchema, prefix='plone')
+.. code-block:: python
 
-  >>> maintenance_settings.days
-  7
+   >>> from Products.CMFPlone.interfaces import IMaintenanceSchema
+   >>> maintenance_settings = registry.forInterface(IMaintenanceSchema, prefix='plone')
+
+   >>> maintenance_settings.days
+   7
 
 
 Navigation Control Panel
 ------------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import INavigationSchema
-  >>> navigation_settings = registry.forInterface(INavigationSchema, prefix='plone')
+.. code-block:: python
 
-  >>> navigation_settings.generate_tabs
-  True
+   >>> from Products.CMFPlone.interfaces import INavigationSchema
+   >>> navigation_settings = registry.forInterface(INavigationSchema, prefix='plone')
 
-  >>> navigation_settings.nonfolderish_tabs
-  True
+   >>> navigation_settings.generate_tabs
+   True
 
-  >>> navigation_settings.displayed_types
-  ('Image', 'File', 'Link', 'News Item', 'Folder', 'Document', 'Event')
+   >>> navigation_settings.nonfolderish_tabs
+   True
 
-  >>> navigation_settings.filter_on_workflow
-  False
+   >>> navigation_settings.displayed_types
+   ('Image', 'File', 'Link', 'News Item', 'Folder', 'Document', 'Event')
 
-  >>> navigation_settings.workflow_states_to_show
-  ()
+   >>> navigation_settings.filter_on_workflow
+   False
 
-  >>> navigation_settings.show_excluded_items
-  True
+   >>> navigation_settings.workflow_states_to_show
+   ()
+
+   >>> navigation_settings.show_excluded_items
+   True
 
 
 Search Control Panel
 --------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import ISearchSchema
-  >>> search_settings = registry.forInterface(ISearchSchema, prefix='plone')
+.. code-block:: python
 
-  >>> search_settings.enable_livesearch
-  False
+   >>> from Products.CMFPlone.interfaces import ISearchSchema
+   >>> search_settings = registry.forInterface(ISearchSchema, prefix='plone')
 
-  >>> search_settings.types_not_searched
-  (...)
+   >>> search_settings.enable_livesearch
+   False
+
+   >>> search_settings.types_not_searched
+   (...)
 
 
 Site Control Panel
 ------------------
 
-Plone 4.x::
+Plone 4.x
 
-  >>> portal = getSite()
-  >>> portal_properties = getToolByName(portal, "portal_properties")
-  >>> site_properties = portal_properties.site_properties
+.. code-block:: python
+
+   >>> portal = getSite()
+   >>> portal_properties = getToolByName(portal, "portal_properties")
+   >>> site_properties = portal_properties.site_properties
 
   >>> portal.site_title = settings.site_title
-  >>> portal.site_description = settings.site_description
-  >>> site_properties.enable_sitemap = settings.enable_sitemap
-  >>> site_properties.exposeDCMetaTags = settings.exposeDCMetaTags
-  >>> site_properties.webstats_js = settings.webstats_js
+   >>> portal.site_description = settings.site_description
+   >>> site_properties.enable_sitemap = settings.enable_sitemap
+   >>> site_properties.exposeDCMetaTags = settings.exposeDCMetaTags
+   >>> site_properties.webstats_js = settings.webstats_js
 
-  >>> settings.enable_sitemap -> plone.app.layout
+   >>> settings.enable_sitemap -> plone.app.layout
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import ISiteSchema
-  >>> site_settings = registry.forInterface(ISiteSchema, prefix='plone')
+.. code-block:: python
 
-  >>> site_settings.site_title
-  u'Plone site'
+   >>> from Products.CMFPlone.interfaces import ISiteSchema
+   >>> site_settings = registry.forInterface(ISiteSchema, prefix='plone')
 
-  >>> site_settings.exposeDCMetaTags
-  False
+   >>> site_settings.site_title
+   u'Plone site'
 
-  >>> site_settings.enable_sitemap
-  False
+   >>> site_settings.exposeDCMetaTags
+   False
 
-  >>> site_settings.webstats_js
-  u''
+   >>> site_settings.enable_sitemap
+   False
+
+   >>> site_settings.webstats_js
+   u''
 
 
 Overview Control Panel
 ----------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces.controlpanel import IDateAndTimeSchema
-  >>> tz_settings = registry.forInterface(IDateAndTimeSchema, prefix='plone')
+.. code-block:: python
 
-  >>> tz_settings.portal_timezone = 'UTC'
+   >>> from Products.CMFPlone.interfaces.controlpanel import IDateAndTimeSchema
+   >>> tz_settings = registry.forInterface(IDateAndTimeSchema, prefix='plone')
+
+   >>> tz_settings.portal_timezone = 'UTC'
 
 
 Markup Control Panel
 --------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import IMarkupSchema
-  >>> markup_settings = registry.forInterface(IMarkupSchema, prefix='plone')
+.. code-block:: python
 
-  >>> markup_settings.default_type
-  u'text/html'
+   >>> from Products.CMFPlone.interfaces import IMarkupSchema
+   >>> markup_settings = registry.forInterface(IMarkupSchema, prefix='plone')
 
-  >>> markup_settings.allowed_types
-  ('text/html', 'text/x-web-textile')
+   >>> markup_settings.default_type
+   u'text/html'
+
+   >>> markup_settings.allowed_types
+   ('text/html', 'text/x-web-textile')
 
 
 User and Groups Control Panel
 -----------------------------
 
-Plone 5.x::
+Plone 5.x
 
-  >>> from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
-  >>> usergroups_settings = registry.forInterface(IUserGroupsSettingsSchema, prefix='plone')
+.. code-block:: pyton
 
-  >>> usergroups_settings.many_groups
-  False
+   >>> from Products.CMFPlone.interfaces import IUserGroupsSettingsSchema
+   >>> usergroups_settings = registry.forInterface(IUserGroupsSettingsSchema, prefix='plone')
 
-  >>> usergroups_settings.many_users
-  False
+   >>> usergroups_settings.many_groups
+   False
+
+   >>> usergroups_settings.many_users
+   False
 
 
 portal_languages is now a utility
@@ -852,7 +966,7 @@ portal_languages is now a utility
 
 Part of the work on PLIP 13091 (plone.app.multilingual) required to move ``portal_languages`` to a utility.
 
-So code that used to look like this::
+Code that used to look like this::
 
 
   # OLD 4.x approach
@@ -865,25 +979,29 @@ Now it should look like this::
   language_tool.getDefaultLanguage()
 
 
-Tests changes
+Tests Changes
 =============
 
-In Plone 4.x a date or date time widget used to be rendered as a set of input fields::
+In Plone 4.x a date or date time widget used to be rendered as a set of input fields
 
-  # OLD 4.x approach
-  browser_manager.getControl(name='form.widgets.IPublication.effective-year').value = '2015'
-  browser_manager.getControl(name='form.widgets.IPublication.effective-month').value = ['10']
-  browser_manager.getControl(name='form.widgets.IPublication.effective-day').value = '11'
-  browser_manager.getControl(name='form.widgets.IPublication.effective-hour').value = '15'
-  browser_manager.getControl(name='form.widgets.IPublication.effective-min').value = '14'
+.. code-block:: python
 
-Now the same input field will be rendered as a single string input::
+   # OLD 4.x approach
+   browser_manager.getControl(name='form.widgets.IPublication.effective-year').value = '2015'
+   browser_manager.getControl(name='form.widgets.IPublication.effective-month').value = ['10']
+   browser_manager.getControl(name='form.widgets.IPublication.effective-day').value = '11'
+   browser_manager.getControl(name='form.widgets.IPublication.effective-hour').value = '15'
+   browser_manager.getControl(name='form.widgets.IPublication.effective-min').value = '14'
 
-  # NEW in 5.0
-  browser_manager.getControl(name='form.widgets.IPublication.effective').value = '2015-10-11 15:14'
+Now the same input field will be rendered as a single string input
+
+.. code-block:: python
+
+   # NEW in 5.0
+   browser_manager.getControl(name='form.widgets.IPublication.effective').value = '2015-10-11 15:14'
 
 
-Deprecation of ``portal_properties.xml``
+Deprecation Of ``portal_properties.xml``
 ========================================
 
 ``portal_properties.xml`` Generic Setup import step is now deprecated and has been moved to plone.registry.
@@ -892,7 +1010,7 @@ Deprecation of ``portal_properties.xml``
 parentMetaTypesNotToQuery
 -------------------------
 
-::
+.. code-block:: xml
 
   # OLD 4.x approach
   <object name="portal_properties">
@@ -903,7 +1021,9 @@ parentMetaTypesNotToQuery
     </object>
   </object>
 
-Now in ``registry.xml`` should look like::
+Now in ``registry.xml`` should look like
+
+.. code-block:: xml
 
   # NEW in 5.0
   <?xml version="1.0"?>
@@ -921,7 +1041,7 @@ Now in ``registry.xml`` should look like::
 metaTypesNotToList
 ------------------
 
-::
+.. code-block:: xml
 
   # OLD 4.x approach
   <?xml version="1.0"?>
@@ -934,7 +1054,8 @@ metaTypesNotToList
 
 *nothing* should  be done in Plone 5.
 
-The new setting is on ``Products.CMFPlone.interfaces.controlpanel.INavigationSchema.displayed_types`` and it works the other way around.
+The new setting is on ``Products.CMFPlone.interfaces.controlpanel.INavigationSchema.displayed_types``
+and it works the other way around.
 
 Instead of blacklisting content types it whitelists them,
 if you don't want your content type to show there's nothing to do.
@@ -942,7 +1063,7 @@ if you don't want your content type to show there's nothing to do.
 typesLinkToFolderContentsInFC
 -----------------------------
 
-::
+.. code-block:: xml
 
   # OLD 4.x approach
   <?xml version="1.0"?>
@@ -954,7 +1075,9 @@ typesLinkToFolderContentsInFC
     </object>
   </object>
 
-Now in ``registry.xml`` should look like::
+Now in ``registry.xml`` should look like
+
+.. code-block:: xml
 
   # NEW in Plone 5
   <record
@@ -970,7 +1093,7 @@ Now in ``registry.xml`` should look like::
 types_not_searched
 ------------------
 
-::
+.. code-block:: xml
 
   # OLD 4.x approach
   <?xml version="1.0"?>
@@ -983,7 +1106,9 @@ types_not_searched
   </object>
 
 
-Now in ``registry.xml`` should look like::
+Now in ``registry.xml`` should look like
+
+.. code-block:: xml
 
   # NEW in Plone 5
   <?xml version="1.0"?>

--- a/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
+++ b/manage/upgrading/version_specific_migration/p4x_to_p5x_upgrade.rst
@@ -9,17 +9,18 @@ Upgrading Plone 4.x To 5.0
 
 .. note::
 
-   If you want to upgrade add-ons to Plone 5, also see: ../../../develop/addons/upgrade_to_50.rst
+   If you want to upgrade add-ons to Plone 5, also see :doc:`/develop/addons/upgrade_to_50`
 
 
 General Information
 ===================
 
-- Before you upgrade read :doc:`../into.rst` and :doc:`../preparations.rst`.
+- Before you upgrade read :doc:`../intro` and :doc:`../preparations`.
 - Always upgrade from the latest version of 4.x to the latest version of 5.x (at the time of writing 4.3.7 to 5.0.2).
   This will resolve many migration-specific issues.
 - If you have problems don't be afraid to ask for help on http://community.plone.org
-- There is a video of a talk "How to upgrade sites to Plone 5": https://youtu.be/bQ-IpO-7F00?t=1m17s (slides: http://de.slideshare.net/derschmock/upgrade-to-plone-5)
+- There is a `video  <https://youtu.be/bQ-IpO-7F00?t=1m17s>`_ of a talk "How to upgrade sites to Plone 5" and
+  `slides <http://de.slideshare.net/derschmock/upgrade-to-plone-5>`_.
 
 
 Changes Due To Implemented PLIPS

--- a/manage/upgrading/version_specific_migration/plone5_minor_upgrade.rst
+++ b/manage/upgrading/version_specific_migration/plone5_minor_upgrade.rst
@@ -51,13 +51,13 @@ Upgrading
 
 Stop your Plone instance:
 
-.. code-block:: shell
+.. code-block:: console
 
     bin/plonectl stop
 
 Rerun buildout:
 
-.. code-block:: shell
+.. code-block:: console
 
     bin/buildout
 
@@ -65,7 +65,7 @@ This may take a some time, as Plone downloads new releases.
 
 When buildout finishes running, restart your Plone instance:
 
-.. code-block:: shell
+.. code-block:: console
 
      bin/plonectl start
 


### PR DESCRIPTION
Fixes: 

- not working ":doc" inclusions because of file ending
- broken filename (it is called intro not *into*)

Improves:

- add code-blocks
- reST syntax
- line-length
