### PR TITLE
Fix docs for editor configuration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 
 Unreleased
 ==========
-- Documentation for Thumbs and Iconhandling in Plone 
+- Documentation for Thumbs and Iconhandling in Plone
   https://github.com/plone/Products.CMFPlone/issues/1995
   [fgrcon]
 - New metadata catalog column `mime_type`
@@ -16,6 +16,7 @@ Unreleased
 - Remove Deliverance info for theming and refer to diazo.org deployment [fredvd]
 - Improve ReStructuredText Style Guide [svx]
 - Add documentation about TinyMCE styles and formats [davilima6]
+- Improve Editor Guide [tmassman]
 
 
 20160606

--- a/develop/styleguide/editor.rst
+++ b/develop/styleguide/editor.rst
@@ -15,10 +15,10 @@ You only need to install the plugin for your editor of choice, and add the follo
     trim_trailing_whitespace = true
     charset = utf-8
 
-    [{*.py,*.cfg}]
+    [*.{cfg,py}]
     indent_size = 4
 
-    [{*.html,*.dtml,*.pt,*.zpt,*.xml,*.zcml,*.js}]
+    [*.{css,dtml,html,js,pt,xml,zcml,zpt}]
     indent_size = 2
 
     [Makefile]

--- a/develop/styleguide/editor.rst
+++ b/develop/styleguide/editor.rst
@@ -9,11 +9,11 @@ You only need to install the plugin for your editor of choice, and add the follo
 .. code-block:: ini
 
     [*]
-    indent_style = space
+    charset = utf-8
     end_of_line = lf
+    indent_style = space
     insert_final_newline = true
     trim_trailing_whitespace = true
-    charset = utf-8
 
     [*.{cfg,py}]
     indent_size = 4

--- a/develop/styleguide/editor.rst
+++ b/develop/styleguide/editor.rst
@@ -1,4 +1,4 @@
-How to set up your editor
+How To Set Up Your Editor
 =========================
 
 
@@ -28,5 +28,5 @@ You only need to install the plugin for your editor of choice, and add the follo
 dotfiles
 --------
 
-Some Plone developers use dotfiles similar to these: `plone.dotfiles <https://github.com/plone/plone.dotfiles>`_. This might inspire you with your own dotfiles/configuration settings.
-
+Some Plone developers use dotfiles similar to these: `plone.dotfiles <https://github.com/plone/plone.dotfiles>`_.
+This might inspire you with your own dotfiles/configuration settings.


### PR DESCRIPTION
Fixes wrong .editorconfig example file.

Improves rst syntax.