### PR TITLE
Remove grok

### DIFF
--- a/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
@@ -154,11 +154,10 @@ Here is an example that returns our pizza types:
 
 ::
 
-    from five import grok
     from plone.supermodel import model
     from plone.directives import form
 
-    from zope.component import queryUtility
+    from zope.component import queryUtility,provider
 
     from zope import schema
 
@@ -169,7 +168,7 @@ Here is an example that returns our pizza types:
 
     ...
 
-    @grok.provider(IContextSourceBinder)
+    @provider(IContextSourceBinder)
     def availablePizzas(context):
         registry = queryUtility(IRegistry)
 
@@ -184,7 +183,7 @@ Here is an example that returns our pizza types:
         return SimpleVocabulary(terms)
 
 Here, we have defined a function acting as the *IContextSourceBinder*, as
-specified via the *@grok.provider()* decorator. This looks up the
+specified via the *@provider()* decorator. This looks up the
 registry and looks for the record we created with *registry.xml* above
 (remember to re-install the product in the Add-on control panel or the
 *portal\_quickinstaller* tool if you modify this file). We then use the
@@ -235,8 +234,10 @@ initialised with the registry key
 
 ::
 
+    from zope.interface import implementer
+    
+    @implementer
     class RegistrySource(object):
-        grok.implements(IContextSourceBinder)
 
         def __init__(self, key):
             self.key = key
@@ -298,19 +299,18 @@ creating a named utility providing *IVocabularyFactory*, like so:
 
 ::
 
-    from five import grok
     from zope.component import queryUtility
 
     from zope import schema
+    from zope.interface import implementer
     from zope.schema.interfaces import IVocabularyFactory
 
     from zope.schema.vocabulary import SimpleVocabulary
 
     from plone.registry.interfaces import IRegistry
 
-
+    @implementer
     class PizzasVocabulary(object):
-        grok.implements(IVocabularyFactory)
 
         def __call__(self, context):
             registry = queryUtility(IRegistry)

--- a/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
+++ b/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.rst
@@ -157,7 +157,8 @@ Here is an example that returns our pizza types:
     from plone.supermodel import model
     from plone.directives import form
 
-    from zope.component import queryUtility,provider
+    from zope.component import queryUtility
+    from zope.component import provider
 
     from zope import schema
 

--- a/develop/plone/forms/vocabularies.rst
+++ b/develop/plone/forms/vocabularies.rst
@@ -153,9 +153,6 @@ Dynamic vocabularies
 Dynamic vocabularies' values may change run-time.
 They are usually generated based on some context data.
 
-Note that the examples below need grok package installed and <grok:grok package="...">
-directive in configure.zcml.
-
 Complete example with portal_catalog query, vocabulary creation and form
 
 ::
@@ -167,8 +164,7 @@ Complete example with portal_catalog query, vocabulary creation and form
         and then this vocabulary is used in Dexterity form.
 
     """
-
-    from five import grok
+    from zope.component import provider
     from plone.directives import form
 
     from zope import schema
@@ -186,7 +182,7 @@ Complete example with portal_catalog query, vocabulary creation and form
         terms = [ SimpleTerm(value=pair[0], token=pair[0], title=pair[1]) for pair in items ]
         return terms
 
-    @grok.provider(IContextSourceBinder)
+    @provider(IContextSourceBinder)
     def course_source(context):
         """
         Populate vocabulary with values from portal_catalog.
@@ -230,13 +226,7 @@ Complete example with portal_catalog query, vocabulary creation and form
         name = schema.TextLine(
                 title=u"Your name",
             )
-
-        courses = schema.List(title=u"Promoted courses",
-                              required=False,
-                              value_type=schema.Choice(source=course_source)
-                              )
-
-    class MyForm(form.SchemaForm):
+class MyForm(form.SchemaForm):
         """ Define Form handling
 
         This form can be accessed as http://yoursite/@@my-form
@@ -250,6 +240,12 @@ Complete example with portal_catalog query, vocabulary creation and form
         ignoreContext = True
 
         @button.buttonAndHandler(u'Ok')
+        courses = schema.List(title=u"Promoted courses",
+                              required=False,
+                              value_type=schema.Choice(source=course_source)
+                              )
+
+    
         def handleApply(self, action):
             data, errors = self.extractData()
             if errors:
@@ -273,9 +269,8 @@ Complex example 2
 
 .. code-block:: python
 
-
-    from five import grok
-    from zope.schema.interfaces import IContextSourceBinder
+    from zope.component import provider
+    from zope.schema.interfaces import IContextSourceBinder,implementer
     from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
     from Products.CMFCore.utils import getToolByName
     from plone.i18n.normalizer import idnormalizer
@@ -286,7 +281,7 @@ Complex example 2
         return terms
 
 
-    @grok.provider(IContextSourceBinder)
+    @provider(IContextSourceBinder)
     def area_source(context):
         """
         Populate vocabulary with values from portal_catalog.

--- a/develop/plone/forms/vocabularies.rst
+++ b/develop/plone/forms/vocabularies.rst
@@ -270,7 +270,8 @@ Complex example 2
 .. code-block:: python
 
     from zope.component import provider
-    from zope.schema.interfaces import IContextSourceBinder,implementer
+    from zope.schema.interfaces import IContextSourceBinder
+    from zope.schema.interfaces import implementer
     from zope.schema.vocabulary import SimpleVocabulary, SimpleTerm
     from Products.CMFCore.utils import getToolByName
     from plone.i18n.normalizer import idnormalizer


### PR DESCRIPTION
Fixes: #936 

Changes proposed in this pull request:

These files were changed to remove grok

https://docs.plone.org/develop/addons/schema-driven-forms/customising-form-behaviour/vocabularies.html
https://docs.plone.org/develop/plone/forms/vocabularies.html

Comment : 
```
class MyForm(form.SchemaForm):
        """ Define Form handling

        This form can be accessed as http://yoursite/@@my-form

        """
        grok.name('my-form')
        grok.require('zope2.View')
        grok.context(ISiteRoot)

        schema = IMyForm
        ignoreContext = True

        @button.buttonAndHandler(u'Ok')
```
I was looking at the code, how do i convert this part?

