### PR TITLE
remove duplicate placement of the javascript/ajax section

### DIFF
--- a/develop/addons/index.rst
+++ b/develop/addons/index.rst
@@ -68,7 +68,6 @@ Working with JavaScript
    :maxdepth: 2
 
    javascript/index
-   javascript/ajax
 
 Background
 ==========


### PR DESCRIPTION

![selection_558](https://user-images.githubusercontent.com/893142/37615153-d9cacdc6-2bac-11e8-85f5-6e3af57a6e10.png)

remove duplicate placement of the javascript/ajax section, it shows up twice in the contents, but is really the same document


