### PR TITLE
Revert "Update basics.rst as default TinyMCE image is broken"

### DIFF
--- a/working-with-content/using-tinymce-as-visual-editor/basics.rst
+++ b/working-with-content/using-tinymce-as-visual-editor/basics.rst
@@ -5,7 +5,7 @@ Basic options of TinyMCE.
 
 The default TinyMCE editor will look like this:
 
-.. figure:: https://user-images.githubusercontent.com/33842949/37874357-1c1af78a-304b-11e8-9f8f-b01f8a01ef53.png
+.. figure:: ../../_robot/tinymce.png
    :align: center
    :alt:
 


### PR DESCRIPTION
Reverts plone/documentation#984

This is not how we include pictures, we use robot tests or if that is not possible we place image into our docs itself.