### PR TITLE
Correct invalid bobtemplates.plone invocations

### DIFF
--- a/develop/addons/bobtemplates.plone/README.rst
+++ b/develop/addons/bobtemplates.plone/README.rst
@@ -28,11 +28,11 @@ bobtemplates introduction
 
 To create a package like ``collective.myaddon``::
 
-    $ mrbob -O collective.myaddon bobtemplates:plone_addon
+    $ mrbob -O collective.myaddon bobtemplates.plone:addon
 
 You can also create a package with nested namespace::
 
-    $ mrbob -O collective.foo.myaddon bobtemplates:plone_addon
+    $ mrbob -O collective.foo.myaddon bobtemplates.plone:addon
 
 
 Options
@@ -114,7 +114,7 @@ Use in a buildout
 This creates a mrbob-executeable in your bin-directory.
 Call it from the ``src``-directory of your Plone project like this.::
 
-    $ ../bin/mrbob -O collective.foo bobtemplates:plone_addon
+    $ ../bin/mrbob -O collective.foo bobtemplates.plone:addon
 
 
 Installation in a virtualenv
@@ -128,7 +128,7 @@ You can also install ``bobtemplates.plone`` in a virtualenv.::
 
 Now you can use it like this::
 
-    $ mrbob -O collective.foo bobtemplates:plone_addon
+    $ mrbob -O collective.foo bobtemplates.plone:addon
 
 See `mr.bob`_ documentation for further information.
 


### PR DESCRIPTION
The docs as they are try to load a template from a namespace package, causing an error:

    AttributeError: 'module' object has no attribute '__file__'
