### PR TITLE
fix broken link

### DIFF
--- a/develop/plone/serving/http_request_and_response.rst
+++ b/develop/plone/serving/http_request_and_response.rst
@@ -765,7 +765,7 @@ Cross-origin resource sharing (CORS)
 
 .. _ZServer: https://github.com/zopefoundation/ZServer/blob/master/src/ZServer/README.txt
 
-.. _Medusa: http://www.amk.ca/python/code/medusa.html
+.. _Medusa: https://web.archive.org/web/20110714080523/http://www.amk.ca/python/code/medusa.html
 
 .. _ZPublisher: http://www.python.org/
 


### PR DESCRIPTION
The link to Sam Rushing's Medusa page is no longer directly available, so I replaced it with a link from archive.org.

Fixes:  a broken link

Improves: usability

Changes proposed in this pull request:

- replace broken link with a working one from archive.org