### PR TITLE
remove redundant comment and import statement

### DIFF
--- a/develop/plone/serving/http_request_and_response.rst
+++ b/develop/plone/serving/http_request_and_response.rst
@@ -224,8 +224,6 @@ A Management Interface Python script to dump all HTTP request headers::
 
     from StringIO import StringIO
 
-    # Import a standard function, and get the HTML request and response objects.
-    from Products.PythonScripts.standard import html_quote
     request = container.REQUEST
     response =  request.response
 


### PR DESCRIPTION
This commit removes the import of "html_quote", as it does not get used in the code snippet below.

The preceding comment was unnecessary in the first place, but after removing the import statement it is even wrong. So it got removed, too.

Improves: readability

Changes proposed in this pull request: see above