### PR TITLE
Update link

### DIFF
--- a/develop/plone/views/viewlets.rst
+++ b/develop/plone/views/viewlets.rst
@@ -45,7 +45,7 @@ More info
 
 * `Plone 4 Viewlet and viewlet manager reference <https://plone.org/documentation/manual/theme-reference/elements/elementsindexsunburst4>`_
 
-* `ZCML viewlet definition <http://apidoc.zope.org/++apidoc++/ZCML/http_co__sl__sl_namespaces.zope.org_sl_browser/viewlet/index.html>`_.
+* `ZCML viewlet definition <https://github.com/zopefoundation/zope.viewlet/blob/master/src/zope/viewlet/metadirectives.py>`_.
 
 * https://pypi.python.org/pypi/zope.viewlet/
 


### PR DESCRIPTION
apidoc.zope.org seems to be gone...

Changes proposed in this pull request:
- fix a broken link