### PR TITLE
guilabel fixes and improvements

### DIFF
--- a/about/contributing/rst-styleguide.rst
+++ b/about/contributing/rst-styleguide.rst
@@ -256,6 +256,16 @@ Strong:
 
    This **word** is in bold text.
 
+Labels for graphical user interfaces (GUI), including buttons, menu items, form controls, and links.
+
+.. code-block:: rst
+
+    Click the :guilabel:`Submit` button.
+
+The above reStructuredText renders as follows.
+
+Click the :guilabel:`Submit` button.
+
 Inline code highlighting:
 
 .. code-block:: rst

--- a/develop/plone/security/standard_permissions.rst
+++ b/develop/plone/security/standard_permissions.rst
@@ -85,7 +85,7 @@ The standard roles in Plone are:
 
 :guilabel:`Reviewer`
      which represents content reviewers separately from site administrators.
-     It is possible to grant the :guilabel:`Reviewer` role locally on the :guilabel:`Sharing`` tab,
+     It is possible to grant the :guilabel:`Reviewer` role locally on the :guilabel:`Sharing` tab,
      where it is shown as :guilabel:`Can review`.
 
 :guilabel:`Member`
@@ -108,7 +108,7 @@ where they appear under more user friendly pseudonyms.
 :guilabel:`Contributor`, aka :guilabel:`Can add`,
     confers the right to add new content.
     As a rule of thumb,
-    the:guilabel: `Contributor` role should have the `Add:guilabel: portal content` permission
+    the :guilabel:`Contributor` role should have the :guilabel:`Add portal content` permission
     and any type-specific add permissions globally
     (i.e. granted in ``rolemap.xml``),
     although these permissions are sometimes managed in workflow as well.


### PR DESCRIPTION
Fixes:
Bad syntax of some `:guilabel:` instances.

Improves:
Adds `:guilabel:` to the reST snippets.

See https://github.com/plone/documentation/pull/1050#discussion_r261817466