### PR TITLE
added rc flag for recursive isort in example

### DIFF
--- a/manage/upgrading/version_specific_migration/upgrade_to_python3.rst
+++ b/manage/upgrading/version_specific_migration/upgrade_to_python3.rst
@@ -193,7 +193,7 @@ You can use ``isort`` to fix the order of imports:
 
 .. code-block:: shell
 
-    ./bin/isort src/collective.package
+    ./bin/isort -rc src/collective.package
 
 After you run the command above, you can fix what ``modernizer`` did not get right.
 


### PR DESCRIPTION
without a flag isort will only sort the imports of the given file(s), since you pass the full package folder we need the flag for recursive (-rc)

Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [ ] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [ ] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Improves:
code example in documentation

