### PR TITLE
Remove outdated reference

### DIFF
--- a/manage/troubleshooting/transactions.rst
+++ b/manage/troubleshooting/transactions.rst
@@ -76,8 +76,8 @@ The code handles both Archetypes and Dexterity subsystems' content types.
 .. note::
 
     Fixing Dexterity blobs with this code has never been tested -
-    please feel free to update the code in collective.developermanual
-    on GitHub if you find it not working properly.
+    please feel free to update the following code example
+    if you find it not working properly.
 
 
 The code, ``fixblobs.py``::


### PR DESCRIPTION
Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [x] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [x] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Improves:

* Database and transactions troubleshooting document

Changes proposed in this pull request:

- Remove an outdated textual reference to collective.developermanual

