### PR TITLE
Custom object actions per portal type

### DIFF
--- a/develop/plone/functionality/actions.rst
+++ b/develop/plone/functionality/actions.rst
@@ -365,6 +365,13 @@ You might want to have different actions for different site sections or folders.
 
 * http://plone.293351.n2.nabble.com/Custom-portal-tabs-per-subsection-tp5747768p5747768.html
 
+Custom object and object_buttons actions per portal type
+--------------------------------------------------------
+
+If you need to override or customize an action from ``object_buttons`` that still uses ``CMFFormController`` for a specific ``portal_type``, check:
+
+* https://stackoverflow.com/questions/11218272/plone-reacting-to-object-removal/11225447#11225447
+
 Copy, cut and paste
 ----------------------
 


### PR DESCRIPTION
Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [X] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [X] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Improves:

Changes proposed in this pull request:

- Documentation about custom object actions per portal type that still uses CMFFormController.



