### PR TITLE
Typo fixed

### DIFF
--- a/manage/upgrading/version_specific_migration/upgrade_zodb_to_python3.rst
+++ b/manage/upgrading/version_specific_migration/upgrade_zodb_to_python3.rst
@@ -169,7 +169,7 @@ Depending on your buildout this could look like this:
 
     [buildout]
 
-    parts =+
+    parts +=
         zodbupdate
 
     auto-checkout +=


### PR DESCRIPTION
Code of the buildout to "Prepare [The] Buildout For Migrating The Database To Python 3" contained `parts =+`  instead of `parts +=`.

Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [x] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [x] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Fixes: typo

Changes proposed in this pull request: `parts +=` instead of `parts =+`.