### PR TITLE
Add info about ContentProviderLookupError

### DIFF
--- a/develop/plone/views/viewlets.rst
+++ b/develop/plone/views/viewlets.rst
@@ -104,6 +104,10 @@ A viewlet manager can be rendered in a page template code using the following ex
 
   <div tal:replace="structure provider:viewletmanagerid" />
 
+.. note::
+
+    If you get a ``ContentProviderLookupError: viewletmanagerid`` you are trying to render a Plone page frame in a context which has no acquisition chain properly set up. Check `exceptions documentation <https://docs.plone.org/manage/troubleshooting/exceptions.html#contentproviderlookuperror-plone-htmlhead>`_ for more details.
+
 Each viewlet manager allows you to shuffle viewlets inside a viewlet manager.
 This is done by using ``/@@manage-viewlets`` view. These settings
 are stored in the site database, so a good practice is to export ``viewlets.xml``


### PR DESCRIPTION
Although already documented, it's nice to warn here as well about acquisition chain.

Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [X] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [X] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Fixes: #
N/A
Improves:
Gives hints about errors that may occur when creating viewletmanagers.
Changes proposed in this pull request:

- Add info about `ContentProviderLookupError`
