### PR TITLE
Enable logging in unit-tests: Clarify and simplify the example and code

### DIFF
--- a/develop/testing/unit_testing.rst
+++ b/develop/testing/unit_testing.rst
@@ -127,7 +127,7 @@ Setting log level in unit tests
 
 Unit tests disable logging to stdout.
 Some important messages may go unnoticed during the unit test development.
-You may also want to set the loglevel from ``INFO`` to ``DEBUG``.
+To reveal these messages, change the log level from ``INFO`` to ``DEBUG``.
 
 To enable logging to stdout do add the following to your test setup code::
 

--- a/develop/testing/unit_testing.rst
+++ b/develop/testing/unit_testing.rst
@@ -129,7 +129,9 @@ Unit tests disable logging to stdout.
 Some important messages may go unnoticed during the unit test development.
 To reveal these messages, change the log level from ``INFO`` to ``DEBUG``.
 
-To enable logging to stdout do add the following to your test setup code::
+To enable logging to stdout, add the following to your test setup code.
+
+.. code-block:: python
 
     import logging
     import sys

--- a/develop/testing/unit_testing.rst
+++ b/develop/testing/unit_testing.rst
@@ -125,18 +125,30 @@ Miscellaneous hints
 Setting log level in unit tests
 -------------------------------
 
-Many components use the ``DEBUG`` output level, while the default output
-level for unit testing is ``INFO``.  Import messages may go unnoticed during
-the unit test development.
+Unit tests disable logging to stdout.
+Some important messages may go unnoticed during the unit test development.
+You may also want to set the loglevel from ``INFO`` to ``DEBUG``.
 
-Add this to your unit test code::
+To enable logging to stdout do add the following to your test setup code::
 
-    def enableDebugLog(self):
-        """ Enable context.plone_log() output from Python scripts """
-        import sys, logging
-        from Products.CMFPlone.log import logger
-        logger.root.setLevel(logging.DEBUG)
-        logger.root.addHandler(logging.StreamHandler(sys.stdout))
+    import logging
+    import sys
+
+
+    def enableLogging(loglevel=logging.INFO):
+        """Enable logging in unit tests.
+        """
+        logging.root.setLevel(loglevel)
+        logging.root.addHandler(logging.StreamHandler(sys.stdout))
+
+
+    class MyTestLayer(PloneSandboxLayer):
+        [...]
+
+        def setUpPloneSite(self, portal):
+            enableLogging(logging.DEBUG)  # Enable logging and optionally set
+                                          # to a different log level.
+
 
 Test outgoing email messages
 ----------------------------


### PR DESCRIPTION
Improves: Section: "Setting log level in unit tests"

Changes proposed in this pull request:

- Simplify the example code by not depending on ``Products.CMFPlone.log``

- Make the problem clearer (log stdout logging at all)

- Make it clearer how to use.

I did not change the heading although I think "Enable logging to stdout in unit tests" would be better. But that would break existing references to this section.

