### PR TITLE
TypeError when creating theme addon

### DIFF
--- a/adapt-and-extend/theming/theme_product.rst
+++ b/adapt-and-extend/theming/theme_product.rst
@@ -29,7 +29,7 @@ and to install the needed bobtemplates for Plone, do::
 
 Create a Plone 5 theme product skeleton with mrbob::
 
-   $ mrbob -O plonetheme.tango bobtemplates:plone_addon
+   $ mrbob -O plonetheme.tango bobtemplates.plone:addon
 
 It will ask you some questions::
 


### PR DESCRIPTION

Fixes: 
Executing mrbob fails with
TypeError: expected str, bytes or os.PathLike object, not NoneType
See https://github.com/domenkozar/mr.bob/issues/89

Changes proposed in this pull request:
Fix documentation
