### PR TITLE
Alternative to enable captcha after installing pfg

### DIFF
--- a/working-with-content/managing-content/ploneformgen/captcha.rst
+++ b/working-with-content/managing-content/ploneformgen/captcha.rst
@@ -13,7 +13,7 @@ When PFG is installed in a Plone instance via add/remove products, it will look 
 
 If you are using collective.recaptcha, you need to take the additional step of setting your public/private keypair. You get these by setting up an account at recaptcha.net. The account is free. You may specify your keypair in the PFG configlet in your site settings.
 
-If you add a captcha facility *after* installing PFG, to enable captcha support, you will need to add `FormCaptchaField` as an allowed content type to `FormFolder` in `portal_types` or reinstall PFG (via add/remove products).
+If you add a CAPTCHA facility *after* installing PFG, to enable CAPTCHA support you will need to add ``FormCaptchaField`` as an allowed content type to ``FormFolder`` in ``portal_types`` or reinstall PFG via :menuselection:`Site Setup > Add-ons`.
 
 .. note::
 

--- a/working-with-content/managing-content/ploneformgen/captcha.rst
+++ b/working-with-content/managing-content/ploneformgen/captcha.rst
@@ -13,6 +13,8 @@ When PFG is installed in a Plone instance via add/remove products, it will look 
 
 If you are using collective.recaptcha, you need to take the additional step of setting your public/private keypair. You get these by setting up an account at recaptcha.net. The account is free. You may specify your keypair in the PFG configlet in your site settings.
 
+If you add a captcha facility *after* installing PFG, to enable captcha support, you will need to add `FormCaptchaField` as an allowed content type to `FormFolder` in `portal_types` or reinstall PFG (via add/remove products).
+
 .. note::
 
     If you add a captcha facility *after* installing PFG, you will need to reinstall PFG (via add/remove products) to enable captcha support.
@@ -34,5 +36,5 @@ Add the following code to your buildout.cfg to install collective.recaptcha and 
         ...
 
 * Re-run bin/buildout and relaunch your zope/plone instance.
-* Open the PortalQuickinstaller or plone control panel and install (or reinstall if already installed) PloneFornGen.
+* Open the PortalQuickInstaller or plone control panel and install (or reinstall if already installed) PloneFormGen.
 * Open the PloneFormGen configlet in the Plone control Panel and fill in the fields with your Public and Private Keys of your ReCaptcha Account. Obtain keys from `reCaptcha.net <https://www.google.com/recaptcha/intro/invisible.html>`_.


### PR DESCRIPTION
Ref: https://github.com/smcmahon/Products.PloneFormGen/pull/226/commits/a7563e462d1863cbdcdb82eacc222ae6ebcb51e8

Give an alternative to add captcha support without reinstalling the package. Ref: https://community.plone.org/t/when-was-using-reinstall-in-portal-quickinstaller-considered-harmful/4789