### PR TITLE
Updated Links from cmfeditions to Products.CMFEditions and add Dexterity

### DIFF
--- a/develop/plone/content/history.rst
+++ b/develop/plone/content/history.rst
@@ -8,12 +8,13 @@ Introduction
 
 Plone versioning allows you to go back between older edits of the same content object.
 
-`Versioning allows you to restore and diff previous copies of the same content <https://plone.org/documentation/manual/plone-3-user-manual/managing-content/versioning-plone-v3.0-plone-v3.2>`_.
-More about `CMFEditions here <https://plone.org/products/cmfeditions/documentation/refmanual/cmfeditionoverview>`_.
+`Versioning allows you to restore and diff previous copies of the same content <https://docs.plone.org/working-with-content/managing-content/versioning.html>`_.
+More about `CMFEditions here <https://github.com/plone/Products.CMFEditions/tree/master/doc>`_.
 
 See also
 
-* `Versioning tutorial for custom content types <http://www.uwosh.edu/ploneprojects/docs/how-tos/how-to-enable-versioning-history-tab-for-a-custom-content-type/>`_.
+* `Versioning tutorial for Dexterity content types <https://pypi.org/project/plone.app.versioningbehavior/>`_
+* `Old Versioning tutorial for Archetype custom content types <https://web.archive.org/web/20170909085840/http://www.uwosh.edu/ploneprojects/docs/how-tos/how-to-enable-versioning-history-tab-for-a-custom-content-type/>`_.
 
 
 Checking whether versioning is enabled
@@ -56,7 +57,7 @@ Will output (inc. some custom content types)::
 How versioning (CMFEditions) works
 ----------------------------------
 
-* http://svn.zope.de/plone.org/collective/Products.CMFEditions/trunk/doc/DevelDoc.html
+* https://github.com/plone/Products.CMFEditions/blob/master/doc/DevelDoc.txt
 
 .. note::
 


### PR DESCRIPTION
I kept the old UWosh link for Archetypes Stuff now as Archive.org link (original resource gone), Please check against newer resources a second time.

Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [ ] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [ ] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Fixes: 

- Fix broken Link to new Managing Content Documentation

- Changed broken Link to products.cmfeditions for Products.CMFEditions Repository to github

- Changed broken Link to old Plone3 Tutorial to the last available version on archive.org (Can be removed in a next commit)

- Changed broken Link to Products.CMFEditions Developer Docs on github

Improves:

- Added Link to plone.app.versioningbehavior for Dexterity Types

Changes proposed in this pull request:

- No general change of documenation text prosa and code

Maybe the new mix of old text and new links can be misleading. The state before my Pull request, was it anyway. 
**In this case add a Prefix Note: that the shown code is outdated.**


