### PR TITLE
context_state.actions needs a category

### DIFF
--- a/develop/plone/functionality/actions.rst
+++ b/develop/plone/functionality/actions.rst
@@ -293,7 +293,8 @@ Example::
 
     # First argument is action category,
     # we have custom "mobile_actions"
-    self.actions = context_state.actions().get('mobile_actions', None)
+    # return a list of actions
+    self.actions = context_state.actions('mobile_actions')
 
 Tabs (sections)
 ----------------


### PR DESCRIPTION
context_state.actions needs a category, otherwise returns default view&edit


Fixes: the ability to return actions by category

Improves:

Changes proposed in this pull request:

- correct the docs, context_state.actions() returns a list and not a dictionary. A category parameter is needed if we want to retrive that action category.