### PR TITLE
adjust docu for valid and nasty tags in portal_tranforms

### DIFF
--- a/develop/plone/forms/wysiwyg.rst
+++ b/develop/plone/forms/wysiwyg.rst
@@ -8,14 +8,14 @@ WYSIWYG text editing and TinyMCE
 
 
 Introduction
-------------
+============
 
 Plone supports TinyMCE (default), and CKEditor and others through external add-ons.
 
 In Plone 5, TinyMCE and the Plone integration is provided by the `Mockup project <https://github.com/plone/mockup>`_.
 
 Disabling HTML filtering and safe HTML transformation
-------------------------------------------------------
+=====================================================
 
 By default Plone does HTML filtering to prevent `cross-site scripting <http://en.wikipedia.org/wiki/Cross-site_scripting>`_
 attacks. This will make Plone to strip away from HTML
@@ -30,15 +30,32 @@ If you need to put a `<script>` tag on your content text in TinyMCE you can disa
 
         If you don't trust all of your site editors, then this will open your site for an attack.
 
-**Step 1:** Turn off Plone’s safe_html transform. Go to /portal_transforms/safe_html in the Management Interface, and enter a 1 in the ‘disable_transform’ box. This prevents Plone from removing tags and attributes while rendering rich text.
+Step 1: Turn off Plone’s safe_html transform
+--------------------------------------------
 
-**Step 2:** Set the "X-XSS-Protection: 0" response header. This can be done in your frontend webserver such as apache or nginx. Alternatively, if you only need to disable the protection for users who have permission to edit, you can add this to the site’s main_template:
+Go to the Site Setup, HTML Filtering settings (`@@filter-controlpanel`).
+
+Check the `Disable HTML filtering` box.
+
+This prevents Plone from removing tags and attributes while rendering rich text.
+
+Step 2: Set the "X-XSS-Protection: 0" response header
+-----------------------------------------------------
+
+This can be done in your frontend webserver such as Apache or Nginx.
+
+Alternatively, if you only need to disable the protection for users who have permission to edit, you can add this to the site’s main_template:
 
 .. code-block:: bash
 
     tal:define="dummy python:checkPermission('Modify portal content', context) and request.RESPONSE.setHeader('X-XSS-Protection', '0');"
 
-**Step 3:** Add script tag to the list of `extended_valid_elements` of TinyMCE. Go to the Control Panel, TinyMCE settings, Advanced tab. Add to the Other settings field:
+Step 3: Add script tag to the list of `extended_valid_elements` of TinyMCE
+--------------------------------------------------------------------------
+
+Go to the Site Setup, TinyMCE, Advanced tab. 
+
+Add to the Other settings field:
 
 .. code-block:: bash
 
@@ -53,7 +70,7 @@ More info
 
 
 Content linking
----------------
+===============
 
 Plone offers many kind of support and enhancements in site internal content linking
 
@@ -75,7 +92,7 @@ links where shown on the other page as the original context.
    You might need to turn on *Linking by UID* setting on in the site setup if you are migrating from older Plone sites.
 
 Editor preferences
-------------------
+==================
 
 Plone supports user text changeable editor. The active editor is stored in
 the :doc:`user preferences </develop/plone/members/member_profile>`.
@@ -94,7 +111,7 @@ which is Plone core
 * https://github.com/plone/Products.CMFPlone/blob/master/Products/CMFPlone/skins/plone_wysiwyg/wysiwyg_support.pt
 
 Applying styles only edit view
-------------------------------
+==============================
 
 You can use TinyMCE body selector make your CSS class have different styles in view and edit modes (inside TinyMCE)
 
@@ -124,7 +141,7 @@ You can use TinyMCE body selector make your CSS class have different styles in v
 
 
 Customizing TinyMCE options
-----------------------------
+===========================
 
 Plone 4 uses TinyMCE 3. Plone 5 upgraded to TinyMCE 4, which works with a new concept called formats and therefore a new syntax for inline styles: `Your Custom Format's Title|custom_format_id|custom_icon_id`.
 
@@ -206,7 +223,7 @@ Alternatively you can define "Quick access custom formats", namely those accessi
 
 
 Rich text transformations
--------------------------
+=========================
 
 * :doc:`/external/plone.app.dexterity/docs/advanced/rich-text-markup-transformations`
 
@@ -214,13 +231,13 @@ Rich text transformations
 
 
 Hacking TinyMCE JavaScript
---------------------------
+==========================
 
 All JavaScript is built and compiled with Plone 5's new Resource Registry.
 
 
 TinyMCE plug-ins
-----------------
+================
 
 The TinyMCE control panel has the ability to provide custom plugins. Custom plugins
 map to the http://www.tinymce.com/wiki.php/Configuration:external_plugins setting.
@@ -232,7 +249,7 @@ compatibility layer for TinyMCE 3.
 
 
 Adding a new plug-in
----------------------
+====================
 
 Here are instructions how to add new plugins to TinyMCE
 
@@ -253,7 +270,7 @@ Plug-in configuration goes to ``registry.xml`` GS profile with the record:
 
 
 Customizing existing plugin
----------------------------
+===========================
 
 * Go to the Resource Registry control panel
 

--- a/develop/plone/misc/portal_transforms.rst
+++ b/develop/plone/misc/portal_transforms.rst
@@ -24,61 +24,43 @@ so that content managers are allowed to insert iframe, object, embed, param,
 script, style, tags and more into the TinyMCE editor::
 
     import logging
-    from plone import api
-    from Products.PortalTransforms.Transform import make_config_persistent
 
-    logger = logging.getLogger('MY.PACKAGE.setuphandlers')
+    logger = logging.getLogger("MY.PACKAGE.setuphandlers")
 
     def isNotThisProfile(context, marker_file):
         return context.readDataFile(marker_file) is None
 
     def setup_portal_transforms(context):
-        if isNotThisProfile(context, 'MY.PACKAGE-PROFILENAME.txt'): return
+        if isNotThisProfile(context, "MY.PACKAGE-PROFILENAME.txt"): return
 
-        logger.info('Updating portal_transform safe_html settings')
+        logger.info("Updating portal_transform safe_html settings")
 
-        tid = 'safe_html'
+        registry = getUtility(IRegistry, context=portal)
+        settings = registry.forInterface(IFilterSchema, prefix="plone")
 
-        pt = api.portal.get_tool(name='portal_transforms')
-        if not tid in pt.objectIds(): return
+        settings.nasty_tags = ["meta"]
+        settings.valid_tags = [
+            "code", "meter", "tbody", "style", "img", "title", "tt", "tr",
+            "param", "li", "source", "tfoot", "th", "td", "dl", "blockquote",
+            "big", "dd", "kbd", "dt", "p", "small", "output", "div", "em",
+            "datalist", "hgroup", "video", "rt", "canvas", "rp", "sub", "bdo",
+            "sup", "progress", "body", "acronym", "base", "br", "address",
+            "article", "strong", "ol", "script", "caption", "dialog", "col",
+            "h1", "h2, "h3", "h4", "h5", "h6", "header", "table", "span",
+            "area", "mark", "dfn", "var", "cite", "thead", "head", "hr",
+            "link", "ruby", "b", "colgroup", "keygen", "ul", "del", "iframe",
+            "embed", "pre", "figure", "ins", "aside", "html", "nav", "details",
+            "samp", "map", "object", "a", "footer", "i", "q", "command",
+            "time", "audio", "section", "abbr"]
 
-        trans = pt[tid]
+Alternatively, you could use the plone.api to achieve the same result:::
 
-        tconfig = trans._config
-        tconfig['class_blacklist'] = []
-        tconfig['nasty_tags'] = {'meta': '1'}
-        tconfig['remove_javascript'] = 0
-        tconfig['stripped_attributes'] = ['lang', 'valign', 'halign', 'border',
-                                         'frame', 'rules', 'cellspacing',
-                                         'cellpadding', 'bgcolor']
-        tconfig['stripped_combinations'] = {}
-        tconfig['style_whitelist'] = ['text-align', 'list-style-type', 'float',
-                                      'width', 'height', 'padding-left',
-                                      'padding-right'] # allow specific styles for
-                                                       # TinyMCE editing
-        tconfig['valid_tags'] = {
-            'code': '1', 'meter': '1', 'tbody': '1', 'style': '1', 'img': '0',
-            'title': '1', 'tt': '1', 'tr': '1', 'param': '1', 'li': '1',
-            'source': '1', 'tfoot': '1', 'th': '1', 'td': '1', 'dl': '1',
-            'blockquote': '1', 'big': '1', 'dd': '1', 'kbd': '1', 'dt': '1',
-            'p': '1', 'small': '1', 'output': '1', 'div': '1', 'em': '1',
-            'datalist': '1', 'hgroup': '1', 'video': '1', 'rt': '1', 'canvas': '1',
-            'rp': '1', 'sub': '1', 'bdo': '1', 'sup': '1', 'progress': '1',
-            'body': '1', 'acronym': '1', 'base': '0', 'br': '0', 'address': '1',
-            'article': '1', 'strong': '1', 'ol': '1', 'script': '1', 'caption': '1',
-            'dialog': '1', 'col': '1', 'h2': '1', 'h3': '1', 'h1': '1', 'h6': '1',
-            'h4': '1', 'h5': '1', 'header': '1', 'table': '1', 'span': '1',
-            'area': '0', 'mark': '1', 'dfn': '1', 'var': '1', 'cite': '1',
-            'thead': '1', 'head': '1', 'hr': '0', 'link': '1', 'ruby': '1',
-            'b': '1', 'colgroup': '1', 'keygen': '1', 'ul': '1', 'del': '1',
-            'iframe': '1', 'embed': '1', 'pre': '1', 'figure': '1', 'ins': '1',
-            'aside': '1', 'html': '1', 'nav': '1', 'details': '1', 'u': '1',
-            'samp': '1', 'map': '1', 'object': '1', 'a': '1', 'footer': '1',
-            'i': '1', 'q': '1', 'command': '1', 'time': '1', 'audio': '1',
-            'section': '1', 'abbr': '1'}
-        make_config_persistent(tconfig)
-        trans._p_changed = True
-        trans.reload()
+    from plone import api
+
+    custom_nasty_tags = [u"meta]
+    custom_valid_tags = [u"code", u"meter", u"tbody", ...]
+    api.portal.set_registry_record("plone.nasty_tags", custom_nasty_tags)
+    api.portal.set_registry_record("plone.valid_tags", custom_valid_tags)
 
 
 Registering the Import Step Method with Generic Setup


### PR DESCRIPTION
Thank you for your contribution to the Plone Documentation.

Before submitting this PR, please make sure:

- [x] You are following our [Documentation Styleguide](https://docs.plone.org/about/contributing/documentation_styleguide.html)
- [x] You are following our [General Writing Guidelines](https://docs.plone.org/about/contributing/rst-styleguide.html)

Fixes: #1130 

Improves: documentation on safe_html settings from portal_transforms (nasty_tags and valid_tags)
