### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,18 @@
+Thank you for your contribution to the Plone Documentation.
+
+Before submitting this pull request, please make sure you follow our guides:
+
+- [ ] [Contributing to Plone Documentation](https://6.dev-docs.plone.org/contributing/index.html)
+- [ ] [Building and Checking the Quality of Documentation](https://6.dev-docs.plone.org/contributing/setup-build.html)
+- [ ] [General Guide to Writing Documentation](https://6.dev-docs.plone.org/contributing/writing-docs-guide.html)
+
+## Issue Number
+
+- Issue #
+
+## Description
+
+_Write a description of the fixes or improvements._
+
+## Add screenshots or links to a preview of the changes
+


### PR DESCRIPTION
This PR adds a new PR template. Its purpose is to make it easier for another contributor to review the PR without having to dig around to find relevant issues, screenshots, or links to previews elsewhere.

See https://github.com/plone/documentation/issues/1174