### PR TITLE
Update viewlets.rst

### DIFF
--- a/develop/plone/views/viewlets.rst
+++ b/develop/plone/views/viewlets.rst
@@ -481,7 +481,7 @@ Below is a complex example how to expose viewlets without going through a viewle
             # Create viewlet and put it to the acquisition chain
             # Viewlet need initialization parameters: context, request, view
             try:
-                viewlet = factory(context, request, self, None).__of__(context)
+                viewlet = factory(context, request, self, None)
             except TypeError:
                 # Bad constructor call parameters
                 raise RuntimeError(


### PR DESCRIPTION
.__of__(context) is no longer necessary. https://community.plone.org/t/plone-5-2-rendering-viewlet-by-name-plone-docs-example-no-longer-working/12611