### PR TITLE
Remove make storybook from make netlify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,6 @@ netlify:
 	ln -s ../submodules/plone.restapi ./docs/plone.restapi
 	ln -s ../submodules/plone.api/docs ./docs/plone.api
 	cd $(DOCS_DIR) && sphinx-build -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	make storybook
 
 .PHONY: storybook
 storybook:


### PR DESCRIPTION
`make storybook` under `make netlify` takes too long and consumes too many build minutes.