### PR TITLE
Nuke trailing white space.

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -319,7 +319,7 @@ dl.py.function > dt {
   padding: 4px 5px;
 }
 dl.py.function > dt:target {
-  background-color: var(--target-color);  
+  background-color: var(--target-color);
 }
 dl.field-list > dt {
   padding-left: 0;

--- a/docs/_static/searchtools.js
+++ b/docs/_static/searchtools.js
@@ -231,7 +231,7 @@ var Search = {
     }
 
     // Enrich item with parent doc_section title
-    for (i = 0; i < results.length; i++) 
+    for (i = 0; i < results.length; i++)
       results[i][6] = results[i][6] || 'Plone Documentation';
 
     // now sort the results by score (in opposite order of appearance, since the
@@ -259,7 +259,7 @@ var Search = {
         "List of all API methods with descriptions"
       ];
       // ugly hack for plone.api documentation integrated via git submodule
-      parentTitles = Array.isArray(parentTitles) ? parentTitles : ploneApiTitles;      
+      parentTitles = Array.isArray(parentTitles) ? parentTitles : ploneApiTitles;
       let path = item[0].split('/')
         .slice(0, -1);
       path = path.map((el, index) => {
@@ -270,7 +270,7 @@ var Search = {
       })
       let markup = path
         .map((el, idx) => {
-            return `<a href="/${el.path}">${el.title}</a>` 
+            return `<a href="/${el.path}">${el.title}</a>`
           })
       markup.push(`<span class="lastbreadcrumb">${item[1]}</span>`)
       return markup.join('<span class="pathseparator">&gt;</span>');
@@ -308,7 +308,7 @@ var Search = {
         headline.append($('<a/>').attr('href',
           linkUrl +
           highlightstring + item[2]).html(item[1]));
-        
+
         listItem.append(headline);
 
         if (item[3]) {
@@ -543,7 +543,7 @@ var Search = {
           foo = foo.map((el, index) => {
             return `${foo.slice(0, index+1).join('/')}/index`
           })
-      
+
           let parentTitles = foo.map(el => {
             let parentId = docnames.indexOf(el);
             let title = parentId === -1 ? title_documentation : titles[parentId];
@@ -592,7 +592,7 @@ $(document).ready(function() {
   $('input[name="doc_section"]').change(function() {
     this.form.submit();
   });
-  
+
   function clearSearchField() {
     $('#q').val('');
     this.form.submit();


### PR DESCRIPTION
This is a test PR. Feel free to close. But should be fine.

The point is that I have changed `mr.roboto`. It should no longer add the comment to new PRs in documentation to ask you to run the Jenkins tests: this has no use for this repository.
Also, after merge, no "fake commit" is done in `buildout.coredev` for triggering a Jenkins run, as this again is not useful for this repository.
(I did the same for `plone.recipe.zope2instance` just now.)