### PR TITLE
Ignore plone.restapi ideas

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,7 @@ exclude_patterns = [
     "**/README.rst",
     "plone.restapi/.*",
     "plone.restapi/bin",
-    "plone.restapi/docs/source/ideas",
+    "plone.restapi/ideas",
     "plone.restapi/include",
     "plone.restapi/lib",
     "plone.restapi/news",


### PR DESCRIPTION
The `ideas` directory was moved to the project root. This PR fixes its ignore location.