### PR TITLE
Document work around for building documentation on M1 macs

### DIFF
--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -40,6 +40,11 @@ cd documentation
 make html
 ```
 
+```{note}
+If you are using an M1 Mac to build the documentation, there is currently an issue with pyenchant that throws an error that the enchant library can't be found. This happens for example if you installed your Python with pyenv. 
+A work around until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib`
+in the terminal session before you execute `make html`.
+```
 
 (setup-build-available-documentation-builds-label)=
 

--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -42,7 +42,7 @@ make html
 
 ```{note}
 If you are using an M1 Mac to build the documentation, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that throws an error that the enchant library can't be found.
-This happens for example if you installed your Python with pyenv. 
+This happens for example if you install Python 3 with `pyenv` in the default M1 architecture (aarch64), so without following instructions to use Rosetta2 x86 emulation.
 A workaround until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib` in the terminal session before you execute `make html`.
 ```
 

--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -42,7 +42,7 @@ make html
 
 ```{note}
 If you are using an M1 Mac to build the documentation, there is currently an issue with pyenchant that throws an error that the enchant library can't be found. This happens for example if you installed your Python with pyenv. 
-A work around until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib`
+A workaround until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib` in the terminal session before you execute `make html`.
 in the terminal session before you execute `make html`.
 ```
 

--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -41,7 +41,8 @@ make html
 ```
 
 ```{note}
-If you are using an M1 Mac to build the documentation, there is currently an issue with pyenchant that throws an error that the enchant library can't be found. This happens for example if you installed your Python with pyenv. 
+If you are using an M1 Mac to build the documentation, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that throws an error that the enchant library can't be found.
+This happens for example if you installed your Python with pyenv. 
 A workaround until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib` in the terminal session before you execute `make html`.
 in the terminal session before you execute `make html`.
 ```

--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -44,7 +44,6 @@ make html
 If you are using an M1 Mac to build the documentation, there is currently [an issue with pyenchant](https://github.com/pyenchant/pyenchant/issues/265) that throws an error that the enchant library can't be found.
 This happens for example if you installed your Python with pyenv. 
 A workaround until pyenchant is fixed is to run `export PYENCHANT_LIBRARY_PATH=/opt/homebrew/lib/libenchant-2.dylib` in the terminal session before you execute `make html`.
-in the terminal session before you execute `make html`.
 ```
 
 (setup-build-available-documentation-builds-label)=


### PR DESCRIPTION
 where pyenchant doesn't work out of the box, it throws an error that the enchant library cannot be found, when it is installed with homebrew and works natively. 

See last comment at https://github.com/pyenchant/pyenchant/issues/265

