### PR TITLE
Extend the extrahead block with Matomo analytics tag manager

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,12 @@
+{% extends "sphinx_book_theme/layout.html" %}
+{%- block extrahead %}
+{{ super() }}
+<!-- Matomo Tag Manager -->
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+g.async=true; g.src='https://stats.plone.org/js/container_RMz5J9EL.js'; s.parentNode.insertBefore(g,s);
+</script>
+<!-- End Matomo Tag Manager -->
+{% endblock %}


### PR DESCRIPTION
This PR adds the Matomo analytics tag manager by extending the `extrahead` template block and using `super()` to inherit this block from its parent theme.