### PR TITLE
Allow configuration of source replacements.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -279,3 +279,21 @@ latex_logo = "_static/logo_2x.png"
 html_context = {
     "edit_page_url_template": "https://6.dev-docs.plone.org/contributing/index.html?{{ file_name }}#making-contributions-on-github",
 }
+
+# An extension that allows replacements for code blocks that
+# are not supported in `rst_epilog` or other substitutions.
+# https://stackoverflow.com/a/56328457/2214933
+def source_replace(app, docname, source):
+    result = source[0]
+    for key in app.config.source_replacements:
+        result = result.replace(key, app.config.source_replacements[key])
+    source[0] = result
+
+# Dict of replacements.
+source_replacements = {
+    "{PLONE_BACKEND_VERSION}": "6.0.0b2",
+}
+
+def setup(app):
+   app.add_config_value('source_replacements', {}, True)
+   app.connect('source-read', source_replace)

--- a/docs/install/containers/examples/haproxy-plone-zeo.md
+++ b/docs/install/containers/examples/haproxy-plone-zeo.md
@@ -40,7 +40,7 @@ services:
       LOG_LEVEL: "info"
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     restart: always
     environment:
       ZEO_ADDRESS: zeo:8100

--- a/docs/install/containers/examples/nginx-plone.md
+++ b/docs/install/containers/examples/nginx-plone.md
@@ -76,7 +76,7 @@ services:
     - "80:80"
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     environment:
       SITE: Plone
       TYPE: classic

--- a/docs/install/containers/examples/nginx-volto-plone-postgresql.md
+++ b/docs/install/containers/examples/nginx-volto-plone-postgresql.md
@@ -106,7 +106,7 @@ services:
       - backend
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     environment:
       SITE: Plone
       RELSTORAGE_DSN: "dbname='plone' user='plone' host='db' password='plone'"

--- a/docs/install/containers/examples/nginx-volto-plone-zeo.md
+++ b/docs/install/containers/examples/nginx-volto-plone-zeo.md
@@ -106,7 +106,7 @@ services:
       - backend
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     environment:
       SITE: Plone
       ZEO_ADDRESS: db:8100

--- a/docs/install/containers/examples/nginx-volto-plone.md
+++ b/docs/install/containers/examples/nginx-volto-plone.md
@@ -104,7 +104,7 @@ services:
       - backend
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     environment:
       SITE: Plone
     volumes:

--- a/docs/install/containers/images/backend.md
+++ b/docs/install/containers/images/backend.md
@@ -18,7 +18,7 @@ This chapter covers Plone backend [Docker](https://www.docker.com/) images using
 ### Simple usage
 
 ```shell
-docker run -p 8080:8080 plone/plone-backend:6.0.0a6 start
+docker run -p 8080:8080 plone/plone-backend:{PLONE_BACKEND_VERSION} start
 ```
 
 Then point your browser at `http://localhost:8080`.
@@ -66,13 +66,13 @@ To recreate the Plone site when restarting the container, you can pass the `DELE
 Plone 6 example:
 
 ```shell
-docker run -p 8080:8080 -e ADDONS="eea.api.layout" -e SITE="Plone" -e PROFILES="eea.api.layout:default" plone/plone-backend:6.0.0a6
+docker run -p 8080:8080 -e ADDONS="eea.api.layout" -e SITE="Plone" -e PROFILES="eea.api.layout:default" plone/plone-backend:{PLONE_BACKEND_VERSION}
 ```
 
 Plone 6 Classic example:
 
 ```shell
-docker run -p 8080:8080 -e ADDONS="eea.facetednavigation" -e SITE="Plone" -e TYPE="classic" -e PROFILES="eea.facetednavigation:default" plone/plone-backend:6.0.0a6
+docker run -p 8080:8080 -e ADDONS="eea.facetednavigation" -e SITE="Plone" -e TYPE="classic" -e PROFILES="eea.facetednavigation:default" plone/plone-backend:{PLONE_BACKEND_VERSION}
 ```
 
 ```{warning}
@@ -106,7 +106,7 @@ version: "3"
 services:
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     restart: always
     environment:
       ZEO_ADDRESS: zeo:8100
@@ -174,7 +174,7 @@ version: "3"
 services:
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     environment:
       RELSTORAGE_DSN: "dbname='plone' user='plone' host='db' password='plone'"
     ports:
@@ -224,13 +224,13 @@ It is possible to install add-ons during startup time in a container created usi
 To do so, pass the `ADDONS` environment variable with a space separated list of requirements to be added to the image:
 
 ```shell
-docker run -p 8080:8080 -e ADDONS="pas.plugins.authomatic" plone/plone-backend:6.0.0a6 start
+docker run -p 8080:8080 -e ADDONS="pas.plugins.authomatic" plone/plone-backend:{PLONE_BACKEND_VERSION} start
 ```
 
 This approach also allows you to test Plone with a specific version of one of its core components
 
 ```shell
-docker run -p 8080:8080 -e ADDONS="plone.volto==3.1.0a3" plone/plone-backend:6.0.0a6 start
+docker run -p 8080:8080 -e ADDONS="plone.volto==3.1.0a3" plone/plone-backend:{PLONE_BACKEND_VERSION} start
 ```
 
 ```{warning}
@@ -248,13 +248,13 @@ To do so, pass the `DEVELOP` environment variable with a space separated list of
 These packages will be installed with `pip install --editable`.
 
 ```shell
-docker run -p 8080:8080 -e DEVELOP="/app/src/mysite.policy" plone/plone-backend:6.0.0a6 start
+docker run -p 8080:8080 -e DEVELOP="/app/src/mysite.policy" plone/plone-backend:{PLONE_BACKEND_VERSION} start
 ```
 
 This approach also allows you to develop local packages by using a volume.
 
 ```shell
-docker run -p 8080:8080 -e DEVELOP="/app/src/mysite.policy" -v /path/to/mysite.policy:/app/src/mysite.policy plone/plone-backend:6.0.0a6 start
+docker run -p 8080:8080 -e DEVELOP="/app/src/mysite.policy" -v /path/to/mysite.policy:/app/src/mysite.policy plone/plone-backend:{PLONE_BACKEND_VERSION} start
 ```
 
 ```{warning}
@@ -267,7 +267,7 @@ We advise against using this feature on production environments.
 In a directory create a  `Dockerfile` file:
 
 ```Dockerfile
-FROM plone/plone-backend:6.0.0a6
+FROM plone/plone-backend:{PLONE_BACKEND_VERSION}
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc \

--- a/docs/install/containers/images/frontend.md
+++ b/docs/install/containers/images/frontend.md
@@ -100,7 +100,7 @@ version: "3"
 services:
 
   backend:
-    image: plone/plone-backend:6.0.0a6
+    image: plone/plone-backend:{PLONE_BACKEND_VERSION}
     # Plone 5.2 series can be used too
     # image: plone/plone-backend:5.2.7
     ports:

--- a/docs/install/containers/index.md
+++ b/docs/install/containers/index.md
@@ -59,7 +59,7 @@ Consult [Get Docker](https://docs.docker.com/get-docker/) for details.
 First start the Plone Backend, naming it `plone6-backend` and creating a site with its default configuration, using the following command.
 
 ```shell
-docker run --name plone6-backend -e SITE=Plone -e CORS_ALLOW_ORIGIN='*' -d -p 8080:8080 plone/plone-backend:6.0.0a6
+docker run --name plone6-backend -e SITE=Plone -e CORS_ALLOW_ORIGIN='*' -d -p 8080:8080 plone/plone-backend:{PLONE_BACKEND_VERSION}
 ```
 
 Now start the Plone Frontend, linking it to the `plone6-backend`:

--- a/docs/install/source-step-by-step.md
+++ b/docs/install/source-step-by-step.md
@@ -67,7 +67,7 @@ site-packages/
 Install Plone 6 with constrained requirements using `pip`.
 
 ```shell
-pip install Plone -c https://dist.plone.org/release/6.0.0a6/constraints.txt
+pip install Plone -c https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/constraints.txt
 ```
 
 ````{admonition} mkwsgiinstance's minimal Zope configuration
@@ -102,7 +102,7 @@ mkwsgiinstance -u admin:admin -d .
 python3.9 -m venv venv
 source venv/bin/activate
 pip install -U pip wheel
-pip install Plone -c https://dist.plone.org/release/6.0.0a6/constraints.txt
+pip install Plone -c https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/constraints.txt
 mkwsgiinstance -u admin:admin -d .
 ```
 ````
@@ -246,7 +246,7 @@ If you want to checkout a Plone Core package for development or just want to ove
 
 ```
 # constraints.txt with unresolvable version conflict
--c https://dist.plone.org/release/6.0.0a6/constraints.txt
+-c https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/constraints.txt
 plone.api>=2.0.0a3
 ```
 
@@ -274,7 +274,7 @@ collective.easyform
 {file}`constraints.txt`
 
 ```ini
--c https://dist.plone.org/release/6.0.0a6/constraints.txt
+-c https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/constraints.txt
 
 # constraints of add-ons
 collective.easyform==3.4.5

--- a/docs/install/source.md
+++ b/docs/install/source.md
@@ -132,7 +132,7 @@ Choose from 1, 2 [1]: 1
 requirements_out [requirements-mxdev.txt]: 
 admin_user [admin]: 
 admin_password []: admin
-plone_version [6.0.0a2]: 6.0.0a6
+plone_version [6.0.0a2]: {PLONE_BACKEND_VERSION}
 listen [localhost:8080]: 
 ```
 
@@ -315,7 +315,7 @@ Paste the following configuration information into it.
 
 ```ini
 [buildout]
-extends = https://dist.plone.org/release/6.0.0a6/versions.cfg
+extends = https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/versions.cfg
 parts = instance
 
 [instance]
@@ -331,7 +331,7 @@ Install Plone with the following shell commands.
 # Create a Python virtual environment in the current directory
 python3.9 -m venv .
 # Install the latest Plone 6 requirements with pip
-bin/pip install -r https://dist.plone.org/release/6.0.0a6/requirements.txt
+bin/pip install -r https://dist.plone.org/release/{PLONE_BACKEND_VERSION}/requirements.txt
 # Run buildout to install Plone 6
 bin/buildout
 # Start the Plone instance


### PR DESCRIPTION
This PR adds support for replacements within `code-block` directives that are not provided by `rst_epilog` or other substititutions.

The first key allows us to enter a value for `PLONE_BACKEND_VERSION` in `conf.py`, and it will automatically render its value in 25 places.

See https://github.com/plone/plone-backend/pull/66#issuecomment-1243065360 and https://stackoverflow.com/a/56328457/2214933.

h/t @davisagli 