### PR TITLE
Undo `html_static_path` configuration in `plone/documentation`, and res…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,7 +129,6 @@ html_extra_path = [
 
 html_static_path = [
     "_static",
-    "volto/_static/volto/img",
 ]
 
 # -- Options for myST markdown conversion to html -----------------------------


### PR DESCRIPTION
…tore image and its referenced path in `plone/volto`.

I just realized I made a huge goof regarding the `html_static_path` configuration. Apparently you don't need to specify a path to copy images from submodules as long as they have a reference in the Markdown files. I failed to realize that Sphinx automagically copies images from submodules into `_build/_images` instead of `_build/_static` and writes the HTML to the appropriate directory. TIL.

This PR puts it all back to normal.

https://github.com/plone/volto/pull/3634 needs to be merged before this PR.