### PR TITLE
Merge glossary terms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,6 +118,7 @@ exclude_patterns = [
     "**/README.rst",
     "plone.restapi/.*",
     "plone.restapi/bin",
+    "plone.restapi/docs/source/glossary.md",  # There can be only one Glossary.
     "plone.restapi/ideas",
     "plone.restapi/include",
     "plone.restapi/lib",

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -450,4 +450,53 @@ make
 
     Make gets its knowledge of how to build your program from a file called the _makefile_, which lists each of the non-source files and how to compute it from other files.
     When you write a program, you should write a makefile for it, so that it is possible to use Make to build and install the program.
+
+REST
+    REST stands for [Representational State Transfer](https://en.wikipedia.org/wiki/Representational_state_transfer). It is a software architectural principle to create loosely coupled web APIs.
+
+workflow
+    A concept in Plone (and other CMS's) whereby a content object can be in a number of states (private, public, etcetera) and uses transitions to change between them (e.g. "publish", "approve", "reject", "retract"). See the [Plone docs on Workflow](https://docs.plone.org/working-with-content/collaboration-and-workflow/)
+
+HTTP-Request
+HTTP Request
+Request
+Requests
+    The initial action performed by a web client to communicate with a server. The {term}`Request` is usually followed by a {term}`Response` by the server, either synchronous or asynchronous (which is more complex to handle on the user side)
+
+HTTP-Response
+HTTP Response
+Response
+    Answer of or action by the server that is executed or send to the client after the {term}`Request` is processed.
+
+HTTP-Header
+HTTP Header
+Header
+    The part of the communication of the client with the server that provides the initialisation of the communication of a {term}`Request`.
+
+HTTP-Verb
+HTTP Verb
+Verb
+    One of the basic actions that can be requested to be executed by the server (on an object) based on the {term}`Request`.
+
+Object URL
+    The target object of the {term}`Request`
+
+Authorization Header
+    Part of the {term}`Request` that is responsible for the authentication related to the right user or service to ask for a {term}`Response`.
+
+Accept Header
+    Part of the {term}`Request` that is responsible to define the expected type of data to be accepted by the client in the {term}`Response`.
+
+Authentication Method
+    Access restriction provided by the connection chain to the server exposed to the client.
+
+Basic Auth
+    A simple {term}`Authentication Method` referenced in the {term}`Authorization Header` that needs to be provided by the server.
+
+content rule
+    A content rule will automatically perform an action when a certain event, known as a {term}`trigger`, takes place.
+
+trigger
+    A trigger is an event in Plone that causes the execution of defined actions.
+    Example triggers include object modified, user logged in, and workflow state changed.
 ```


### PR DESCRIPTION
Only one other PR must be merged before this one.

- https://github.com/plone/plone.restapi/pull/1508
- plone.api: Does not have a glossary, uses main documentation's glossary
- volto: Does not have a glossary, uses main documentation's glossary

Fixes https://github.com/plone/documentation/issues/1337