### PR TITLE
Yeoman is required by the cookiecutter

### DIFF
--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -41,6 +41,7 @@ You may host multiple Plone sites on the same server.
 -   Cookiecutter
 -   Node.JS
 -   nvm
+-   Yeoman
 -   Yarn
 -   GNU make
 
@@ -54,6 +55,8 @@ pip install --user --upgrade cookiecutter
 ```
 
 {ref}`Install nvm and Node.js documentation <frontend-getting-started-install-nvm-label>`.
+
+{ref}`Install Yeoman documentation <frontend-getting-started-yeoman-label>`.
 
 {ref}`Install Yarn documentation <frontend-getting-started-yarn-label>`.
 


### PR DESCRIPTION
I also pushed changes to [`plone/volto`'s `master` branch](https://github.com/plone/volto/commit/e8caa4240f3d45cf6f3b0404c5ca56c87d08ca9f) (I was flying on auto-pilot and forgot to create a new branch as I should have before pushing directly, oopsie). 