### PR TITLE
Remove Google Analytics

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,7 +229,6 @@ todo_include_todos = True
 html_use_opensearch = "https://docs.plone.org"
 
 html_theme_options = {
-    "google_analytics_id": "G-P8NCTB796E",
     "path_to_docs": "docs",
     "repository_url": "https://github.com/plone/documentation",
     "repository_branch": "main",


### PR DESCRIPTION
We have Matomo enabled already, and Google is not GDPR compliant.