### PR TITLE
Fix Sphinx WARNING: Document headings start at H2, not H1 [myst.header]

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,6 +128,7 @@ exclude_patterns = [
     "plone.restapi/news",
     "plone.restapi/performance",
     "plone.restapi/src",
+    "volto/developer-guidelines/branch-policy.md",
 ]
 
 html_js_files = [


### PR DESCRIPTION
Refs: https://github.com/plone/volto/pull/4145