### PR TITLE
Fix linkcheckbroken #1396

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ linkcheck: deps  ## Run linkcheck
 
 .PHONY: linkcheckbroken
 linkcheckbroken: deps  ## Run linkcheck and show only broken links
-	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | grep -wi "broken\|redirect" | GREP_COLORS='0;31' grep -vi "https://github.com/plone/volto/issues/" --color=auto || test $$? = 1
+	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=always | GREP_COLORS='0;31' grep -vi "https://github.com/plone/volto/issues/" --color=always && if test $$? = 0; then exit 1; fi || test $$? = 1
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 		"or in $(BUILDDIR)/linkcheck/ ."

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ linkcheck_ignore = [
     r"https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md#finished-proposals",
     r"https://coveralls.io/repos/github/plone/plone.restapi/badge.svg\?branch=master",  # plone.restapi
     r"https://github.com/plone/plone.restapi/blob/dde57b88e0f1b5f5e9f04e6a21865bc0dde55b1c/src/plone/restapi/services/content/add.py#L35-L61",  # plone.restapi
+    r"https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-version-10-0",  # volto
 ]
 linkcheck_anchors = True
 linkcheck_timeout = 10

--- a/docs/contributing/setup-build.md
+++ b/docs/contributing/setup-build.md
@@ -40,7 +40,7 @@ Vale also has [integrations](https://vale.sh/docs/integrations/guide/) with vari
 Plone documentation uses a file located at the root of the repository, `.vale.ini`, to configure Vale.
 This file allows overriding rules or changing their severity.
 
-The Plone Documentation Team selected the [Microsoft Writing Style Guide](https://docs.microsoft.com/en-us/style-guide/welcome/) for its ease of use—especially for non-native English readers and writers—and attention to non-technical audiences. 
+The Plone Documentation Team selected the [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/) for its ease of use—especially for non-native English readers and writers—and attention to non-technical audiences. 
 
 ```{note}
 More corrections to spellings and Vale's configuration are welcome by submitting a pull request.


### PR DESCRIPTION
When grep matches a line, it returns an exit code of 0, but we want it to return 1 because it means it found a broken or redirect link.

This also needs to be updated for all the submodules, except without the Volto exclusion for issues for plone.restapi and plone.api.

Fixes #1396.