### PR TITLE
Add custom 404 not found page

### DIFF
--- a/docs/_templates/404.html
+++ b/docs/_templates/404.html
@@ -1,0 +1,19 @@
+{% extends "!page.html" %}
+
+{%- block htmltitle %}
+<title>{{ title|striptags|e }}{%- for parent in parents %} – {{ parent.title }}{%- endfor %}{{ titlesuffix }}</title>
+{%- endblock %}
+
+{% block body %}
+<div>
+    <h1>Page not found</h1>
+    <p>Unfortunately we couldn't find the content you were looking for.</p>
+</div>
+
+<style>
+    /* Hide empty sub menu. */
+    .sticky-top .bd-toc {
+        visibility: hidden;
+    }
+</style>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx.ext.viewcode",  # plone.api
     "sphinx.ext.autosummary",  # plone.api
+    "notfound.extension",
 ]
 
 
@@ -204,6 +205,12 @@ ogp_custom_meta_tags = [
 # -- sphinx_copybutton -----------------------
 copybutton_prompt_text = r"^ {0,2}\d{1,3}"
 copybutton_prompt_is_regexp = True
+
+
+# -- sphinx-notfound-page configuration ----------------------------------
+
+notfound_urls_prefix = None
+notfound_template = "404.html"
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ sphinx-autobuild
 sphinx-book-theme==0.3.3  # Temporary pin until we can sort out HTML refactoring.
 sphinx-copybutton
 sphinx-design
+sphinx-notfound-page
 sphinx-sitemap
 sphinx-togglebutton
 sphinxcontrib.httpdomain  # plone.restapi
 sphinxcontrib.httpexample  # plone.restapi
 sphinxext-opengraph
-sphinx-notfound-page

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ sphinx-togglebutton
 sphinxcontrib.httpdomain  # plone.restapi
 sphinxcontrib.httpexample  # plone.restapi
 sphinxext-opengraph
+sphinx-notfound-page


### PR DESCRIPTION
error page for 404 is available at /404.html

Minimum solution for issue https://github.com/plone/documentation/issues/1399

**This PR adds a new extension. Please run "make distclean" and rebuild to see the new generated /404.html**

![grafik](https://user-images.githubusercontent.com/1144737/209063987-34426d54-c451-42f0-a62f-127bf775b9f2.png)
