### PR TITLE
Add an `html_static_path` to find static files in volto and copy them…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -140,6 +140,7 @@ html_extra_path = [
 
 html_static_path = [
     "_static",
+    "volto/_static",
 ]
 
 # -- Options for myST markdown conversion to html -----------------------------


### PR DESCRIPTION
… over

https://github.com/plone/volto/pull/4376 needs to be merged first.

I found that it is necessary to explicitly include a value for `html_static_path` to copy over static files from the volto repo.