### PR TITLE
Update deprecated command of `set-output`

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         working-directory: submodules/volto
-        run: echo "{name}={value}" >> $GITHUB_OUTPUT
+        run: echo "{dir}={$(yarn cache dir)}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         working-directory: submodules/volto
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "{name}={value}" >> $GITHUB_OUTPUT
       - uses: actions/cache@v1
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/