### PR TITLE
add docs for static js and css resource registry

### DIFF
--- a/docs/classic-ui/static-resources.md
+++ b/docs/classic-ui/static-resources.md
@@ -15,6 +15,7 @@ We often want to ship a website with a static resource, such as an image, icon, 
 For this, we need to register static resources.
 
 
+(classic-ui-static-resources-registering-label)=
 ## Registering javascript and css
 
 To register a static resource in Plone 6, we need to use the `plone.base.interfaces.resources.IBundleRegistry` interface.
@@ -36,21 +37,6 @@ The js files have to be in the `browser/static` folder of your Plone 6 project.
 
 You can register a CSS resource in the same way.
   
-  ```xml 
-  <registry>
-    <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/css">
-      <value key="enabled">True</value>
-      <value key="csscompilation">++plone++myproject.site/style.min.css</value>
-      <value key="jscompilation">++plone++myproject.site/javascript.min.js</value>
-      <value key="load_async">False</value> 
-      <value key="load_defer">False</value>
-      <value key="depends">plone</value>
-    </records>
-  </registry>
-  ```
-
-Registering a js file and a css file in the same bundle is also possible.
-
 ```xml
     <registry>
     <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/css">
@@ -61,6 +47,20 @@ Registering a js file and a css file in the same bundle is also possible.
   </registry>
 ```
 
+Registering a js file and a css file in the same bundle is also possible.
+
+```xml 
+<registry>
+  <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/css">
+    <value key="enabled">True</value>
+    <value key="csscompilation">++plone++myproject.site/style.min.css</value>
+    <value key="jscompilation">++plone++myproject.site/javascript.min.js</value>
+    <value key="load_async">False</value> 
+    <value key="load_defer">False</value>
+    <value key="depends">plone</value>
+  </records>
+</registry>
+```
 
 (classic-ui-static-resources-available-attributeslabel)=
 

--- a/docs/classic-ui/static-resources.md
+++ b/docs/classic-ui/static-resources.md
@@ -15,12 +15,80 @@ We often want to ship a website with a static resource, such as an image, icon, 
 For this, we need to register static resources.
 
 
+## Registering javascript and css
+
+To register a static resource in Plone 6, we need to use the `plone.base.interfaces.resources.IBundleRegistry` interface.
+
+The following example registers a Javascript resource in `browser/profiles/default/registry` of your Plone 6 project.
+The js files have to be in the `browser/static` folder of your Plone 6 project.
+
+```xml
+<registry>
+  <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/jscript">
+    <value key="enabled">True</value>
+    <value key="jscompilation">++plone++myproject.site/javascript.min.js</value>
+    <value key="load_async">False</value> 
+    <value key="load_defer">False</value>
+    <value key="depends">plone</value>
+  </records>
+</registry>
+```
+
+You can register a CSS resource in the same way.
+  
+  ```xml 
+  <registry>
+    <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/css">
+      <value key="enabled">True</value>
+      <value key="csscompilation">++plone++myproject.site/style.min.css</value>
+      <value key="jscompilation">++plone++myproject.site/javascript.min.js</value>
+      <value key="load_async">False</value> 
+      <value key="load_defer">False</value>
+      <value key="depends">plone</value>
+    </records>
+  </registry>
+  ```
+
+Registering a js file and a css file in the same bundle is also possible.
+
+```xml
+    <registry>
+    <records interface="plone.base.interfaces.resources.IBundleRegistry" prefix="plone.bundles/css">
+      <value key="enabled">True</value>
+      <value key="csscompilation">++plone++myproject.site/style.min.css</value>
+      <value key="depends">plone</value>
+    </records>
+  </registry>
+```
+
+
 (classic-ui-static-resources-available-attributeslabel)=
 
 ## Available attributes
+
+The following attributes are available for registering a static resource:
+
+`enabled`
+:  Whether the bundle is enabled or not. If it is disabled, the bundle will not be loaded.
+
+`jscompilation`
+:  The path to the compiled js file.
+
+`csscompilation`
+:  The path to the compiled css file.
+
+`depends`
+:  A list of bundles that this bundle depends on.
+
+`load_async`
+:  Whether the bundle should be loaded asynchronously or not. *Only JS*
+
+`load_defer`
+:  Whether the bundle should be loaded deferred or not. *Only JS*
 
 
 (classic-ui-static-resources-loading-order-label)=
 
 ## Loading order of resources
 
+`depends` is used to define the loading order of resources, by specifying the name of the depending bundle.

--- a/docs/install/manage-add-ons-packages.md
+++ b/docs/install/manage-add-ons-packages.md
@@ -147,7 +147,7 @@ make start-backend
 ```
 
 ```{seealso}
-See the [documentation of `mxdev` in its README.rst](https://github.com/mxstack/mxdev/blob/main/README.rst) for complete information.
+See the [documentation of `mxdev` in its README.md](https://github.com/mxstack/mxdev/blob/main/README.md) for complete information.
 ```
 
 


### PR DESCRIPTION
As a result of the Alpine City Sprint 2023, I  updated the documentation for static resource registry in the classic ui.