### PR TITLE
Fix layout of search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,8 +139,8 @@ html_extra_path = [
 ]
 
 html_static_path = [
-    "_static",
     "volto/_static",
+    "_static",
 ]
 
 # -- Options for myST markdown conversion to html -----------------------------


### PR DESCRIPTION
Fix order of _static directories. Last wins.
volto/_static or other submodules _static should not overwrite main _static.