### PR TITLE
Volto requires Yarn 3 now. Update make start-frontend output

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -272,7 +272,7 @@ mrs-developer
     As a byproduct of its update operations, it also automatically adjusts `jsconfig.json`, which is used by Volto to configure webpack aliases.
 
 Yarn
-    [Yarn](https://classic.yarnpkg.com/) is a JavaScript package manager.
+    [Yarn](https://yarnpkg.com/) is a JavaScript package manager.
 
 Hydration
     After loading an HTML page generated with {term}`SSR` in the browser, React can populate the existing {term}`DOM` elements, and recreate and attach their coresponding components.

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -159,6 +159,8 @@ Install the latest Yarn 3 version (not the Classic 1.x one) using `npm`.
 
     ```shell
     yarn -v
+    ```
+    ```console
     3.2.3
     ```
 

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -145,20 +145,21 @@ npm install -g yo
 
 (install-prerequisites-yarn-label)=
 
-#### Yarn
+#### Yarn 3
 
-Install the Yarn Classic version (not the latest 2.x one) using `npm`.
+Install the latest Yarn 3 version (not the Classic 1.x one) using `npm`.
 
 1.  Open a terminal and type:
 
     ```shell
-    npm install yarn@1
+    npm install yarn@3
     ```
 
-2.  Verify that Yarn v1.x.x is installed and activated.
+2.  Verify that Yarn v3.x.x is installed and activated.
 
     ```shell
     yarn -v
+    3.2.3
     ```
 
 
@@ -344,8 +345,6 @@ make start-frontend
 The Plone frontend server starts up and emits messages to the console.
 
 ```console
-yarn run v1.22.19
-$ razzle start
  WAIT  Compiling...
 
 
@@ -356,6 +355,7 @@ $ razzle start
   Compiled successfully in 9.62s
 
 ✅  Server-side HMR Enabled!
+sswp> Handling Hot Module Reloading
 Volto is running in SEAMLESS mode
 Using internal proxy: http://localhost:3000 -> http://localhost:8080/Plone
 🎭 Volto started at 0.0.0.0:3000 🚀


### PR DESCRIPTION
As discussed in this morning Volto Team meeting. 