### PR TITLE
Ignore python version save file when using pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 pyvenv.cfg
 /_build
 /styles/Microsoft
+.python-version
 
 # symlinked from submodule
 docs/volto


### PR DESCRIPTION
for python version management as a developer/contribuor to docs.