### PR TITLE
Fixes - 'make html' outputs wrong build dir to find the generated documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PAPER           ?=
 SPHINXBUILD     = $(realpath bin/sphinx-build)
 SPHINXAUTOBUILD = $(realpath bin/sphinx-autobuild)
 DOCS_DIR        = ./docs/
-BUILDDIR        = ../_build/
+BUILDDIR        = ../_build
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .


### PR DESCRIPTION
Closes #1477

I, Adarsh Rawat, agree to have this contribution published under Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.