### PR TITLE
Set value for `sitemap_url_scheme` to correctly add URL entries to si…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -278,7 +278,9 @@ html_title = "%(project)s v%(release)s" % {"project": project, "release": releas
 html_use_index = True
 
 # Used by sphinx_sitemap to generate a sitemap
-html_baseurl = "https://6.docs.plone.org"
+html_baseurl = "https://6.docs.plone.org/"
+# https://sphinx-sitemap.readthedocs.io/en/latest/advanced-configuration.html#customizing-the-url-scheme
+sitemap_url_scheme = "{link}"
 
 # -- Options for HTML help output -------------------------------------------------
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -5,3 +5,4 @@ Disallow: /.doctrees/
 Disallow: /*.txt$
 Disallow: /.buildinfo$
 Disallow: /objects.inv$
+Sitemap: https://6.docs.plone.org/sitemap.xml


### PR DESCRIPTION
…temap.xml.

Currently we have values that follow the default settings value, such as the following. 

`<loc>https://6.docs.plone.org6.0/backend/annotations.html</loc>`

This change fixes the issue.