### PR TITLE
Update contributing docs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -101,7 +101,7 @@ The following text is an example change log entry, placed inside {file}`/news/45
 Fix broken links for ReactJS.org. @stevepiercy
 ```
 
-(contributing-project-configuration-files)
+(contributing-project-configuration-files-label)=
 
 ## Project configuration files
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -101,6 +101,13 @@ The following text is an example change log entry, placed inside {file}`/news/45
 Fix broken links for ReactJS.org. @stevepiercy
 ```
 
+(contributing-project-configuration-files)
+
+## Project configuration files
+
+To standarize the developer experience across packages, a configuration tool is used.
+
+See the [tool documentation](https://github.com/plone/meta) for more information.
 
 (contributing-specific-contribution-policies-for-projects-label)=
 


### PR DESCRIPTION
To mention the use of `plone/meta` in plone repositories.

See https://github.com/plone/meta/pull/128

@stevepiercy I was very brief on purpose, but we can do a bit more introduction if needed. The idea of `plone/meta` is not to be something every developer, specially new ones, are to be using.

But rather something that until you really have some advanced needs, you might need to fiddle with it.