### PR TITLE
Rename the heading for accuracy

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -162,7 +162,7 @@ If no warnings are shown, the add-on should run fine on Zope 5.
 
 (v60-barceloneta-lts-label)=
 
-## Modernize Plone default theme (Barceloneta LTS)
+## Modernize Plone Classic UI theme (Barceloneta)
 
 The standard theme in Classic UI was updated to Bootstrap 5, CSS variables, and an icon library.
 If you have a theme that builds on Barceloneta, you most likely need various changes.


### PR DESCRIPTION
There is confusion between marketing and reality. We market Volto as the "default theme" for Volto 6, but this heading says the default theme is Barceloneta LTS. We should avoid marketing either theme as "default" in documentation to avoid alienating users of either theme. Also LTS for a theme is not a thing.