### PR TITLE
Fix link to plone.app.contenttypes migration of archetypes to dexterity

### DIFF
--- a/docs/backend/upgrading/intro.md
+++ b/docs/backend/upgrading/intro.md
@@ -149,7 +149,7 @@ The following major changes in the history of Plone require special attention wh
 With Plone 5.0 the default framework for content types switched from Archetypes to Dexterity.
 
 Up through Plone 5.2.x, there is a built-in migration from Archetypes to Dexterity, but it only supports Python 2.
-See [Migration](https://pypi.org/project/plone.app.contenttypes/2.2.3/#migration) in the latest stable release of `plone.app.contenttypes` for details on the migration of custom and default content types to Dexterity.
+See [Migration](https://github.com/plone/plone.app.contenttypes/blob/2.2.3/docs/README.rst#migration) in the 2.2.3 release of `plone.app.contenttypes` for details on the migration of custom and default content types to Dexterity.
 
 Using [collective.exportimport](https://pypi.org/project/collective.exportimport/) you can export Archetypes content and import it as Dexterity content.
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-52.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-52.md
@@ -294,7 +294,7 @@ eggs =
 ```{note}
 Instead of using Archetypes in Plone 5.2, you should consider migrating to Dexterity.
 Dexterity is also a hard requirement to be able to use Python 3.
-See [`plone.app.contenttypes` documentation on Migration](https://github.com/plone/plone.app.contenttypes#migration) for details on the migration from Archetypes to Dexterity.
+See [`plone.app.contenttypes` documentation on Migration](https://github.com/plone/plone.app.contenttypes/blob/2.2.3/docs/README.rst#migration) for details on the migration from Archetypes to Dexterity.
 ```
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ linkcheck_ignore = [
     r"https://github.com/nodejs/release#release-schedule",
     r"https://github.com/nvm-sh/nvm#install--update-script",
     r"https://github.com/plone/cookiecutter-zope-instance#options",
-    r"https://github.com/plone/plone.app.contenttypes#migration",
+    r"https://github.com/plone/plone.app.contenttypes/blob/2.2.3/docs/README.rst#migration",
     r"https://github.com/plone/plone.docker#for-basic-usage",
     r"https://github.com/plone/plone.rest#cors",
     r"https://github.com/plone/plone.volto/blob/6f5382c74f668935527e962490b81cb72bf3bc94/src/kitconcept/volto/upgrades.py#L6-L54",


### PR DESCRIPTION
FYI, the link to `plone.app.contenttypes` on PyPI has an anchor that no longer renders and breaks linkcheck, so I used the GitHub link to v2.2.3 with a migration anchor.

https://pypi.org/project/plone.app.contenttypes/2.2.3/#migration

@agitator @vincentfretin @pbauer @jensens