### PR TITLE
Exclude video markup from text output

### DIFF
--- a/docs/contributing/documentation/myst-reference.md
+++ b/docs/contributing/documentation/myst-reference.md
@@ -268,8 +268,10 @@ Note that the path must be absolute to support both submodules and the main docu
 Don't use file-relative paths.
 The above MyST markup renders as shown below.
 
+````{only} not text
 ```{video} /_static/user-manual/blocks/block-copy-cut.mp4
 ```
+````
 
 
 ### Diagrams and graphs with Graphviz


### PR DESCRIPTION
For the Plone Nuclia project, we are experimenting with various outputs for easier indexing. This PR excludes videos from only the text output from the `make text` command. It affects only the text builder.