### PR TITLE
Clean up linkcheck_ignore list

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,30 +74,23 @@ pygments_style = "sphinx"
 # Options for the linkcheck builder
 # Ignore localhost
 linkcheck_ignore = [
-    r"http://localhost",
+    # Ignore local and example URLs
     r"http://0.0.0.0",
     r"http://127.0.0.1",
+    r"http://localhost",
     r"http://yoursite",
-    r"https://www.linode.com",
-    r"https://vhs-ehrenamtsportal.de", # SSLError(SSLCertVerificationError
+    # Ignore file downloads
+    r"^/_static/",
+    # Ignore pages that require authentication
     r"https://github.com/orgs/plone/teams/",  # requires auth
     r"https://github.com/plone/documentation/issues/new/choose",  # requires auth
-    # Ignore specific anchors
-    r"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors#Identifying_the_issue",
-    r"https://github.com/browserslist/browserslist#queries",
-    r"https://github.com/nodejs/release#release-schedule",
-    r"https://github.com/nvm-sh/nvm#install--update-script",
-    r"https://github.com/plone/cookiecutter-zope-instance#options",
-    r"https://github.com/plone/plone.app.contenttypes/blob/2.2.3/docs/README.rst#migration",
-    r"https://github.com/plone/plone.docker#for-basic-usage",
-    r"https://github.com/plone/plone.rest#cors",
-    r"https://github.com/plone/plone.volto/blob/6f5382c74f668935527e962490b81cb72bf3bc94/src/kitconcept/volto/upgrades.py#L6-L54",
     r"https://github.com/plone/volto/issues/new/choose",  # requires auth
-    r"https://github.com/tc39/proposals/blob/HEAD/finished-proposals.md#finished-proposals",
+    # Ignore github.com pages with anchors
+    r"https://github.com/.*#.*",
+    # Ignore other specific anchors
     r"https://coveralls.io/repos/github/plone/plone.restapi/badge.svg\?branch=master",  # plone.restapi
-    r"https://github.com/plone/plone.restapi/blob/dde57b88e0f1b5f5e9f04e6a21865bc0dde55b1c/src/plone/restapi/services/content/add.py#L35-L61",  # plone.restapi
+    r"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors#Identifying_the_issue",
     r"https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-version-10-0",  # volto
-    r"^/_static/",
 ]
 linkcheck_anchors = True
 linkcheck_timeout = 5


### PR DESCRIPTION
Some sites work now, so I removed them from the `linkcheck_ignore` list. GitHub.com has broken more anchor links. This PR simplifies the latter with a regular expression to exclude checking any GitHub page with an anchor. Additionally I organized the URLs into some logical sense and alphanumeric sort within a category.