### PR TITLE
Remove regex from sphinx-copybutton config, now that linenos are exclu…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -204,11 +204,6 @@ ogp_custom_meta_tags = [
 ]
 
 
-# -- sphinx_copybutton -----------------------
-copybutton_prompt_text = r"^ {0,2}\d{1,3}"
-copybutton_prompt_is_regexp = True
-
-
 # -- sphinx-notfound-page configuration ----------------------------------
 
 notfound_urls_prefix = ""


### PR DESCRIPTION
…ded by default

See https://sphinx-copybutton.readthedocs.io/en/latest/use.html#automatic-exclusion-of-prompts-from-the-copies

Fixes #5345.