### PR TITLE
Add spelling terms programatically, pluggab(le|ility), transpile[dr]{…

### DIFF
--- a/styles/Vocab/Plone/accept.txt
+++ b/styles/Vocab/Plone/accept.txt
@@ -12,12 +12,15 @@ npm
 nvm
 Pastanaga
 Plone
+pluggab(le|ility)
+programatically
 portlet
 prerendered
 Razzle
 renderer
 RichText
 Sass
+transpile[dr]{0,1}
 unregister
 viewlet
 Volto


### PR DESCRIPTION
…0,1}

Before:

```console
✖ 1830 errors, 1177 warnings and 4432 suggestions in 335 files.
```

After

```console
✖ 1811 errors, 1177 warnings and 4430 suggestions in 335 files.
```