### PR TITLE
Remove Volto news symlink creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ docs/volto:
 	git submodule init; \
 	git submodule update; \
 	ln -s ../submodules/volto/docs/source ./docs/volto
-	ln -s ../submodules/volto/docs/source/news ./docs/volto/news
 	@echo
 	@echo "Documentation of volto initialized."
 


### PR DESCRIPTION
We do not want to create a symlink in the documentation repo, because this symlink is used only within Volto when checking the validity of the MyST syntax of news items in that repository as they are created.

See https://github.com/plone/volto/pull/5375.