### PR TITLE
Update licenses used in Plone and paths to news

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -25,7 +25,7 @@ Other chapters cover any variations and additional policies for each project.
 
 You must give permission to the Plone Foundation to publish your contribution, according to the license we use.
 Plone uses the [GNU General Public License, version 2](https://github.com/plone/Products.CMFPlone/blob/master/LICENSE) for most of its projects and for any new projects.
-A few other projects use the [modified BSD license](https://opensource.org/license/bsd-3-clause/).
+A few other projects use the [modified BSD license](https://opensource.org/license/bsd-3-clause/), [MIT License](https://opensource.org/license/mit/), or [Creative Commons Attribution-ShareAlike 4.0 International license](https://creativecommons.org/licenses/by-sa/4.0/).
 You grant permission by signing and returning the Plone Contributor Agreement.
 
 ```{button-link} https://plone.org/foundation/contributors-agreement
@@ -71,15 +71,15 @@ All of a project's CI jobs must pass before a contribution may be accepted.
 
 ## Change log entry
 
-Plone projects require that you include a change log entry or news item with your contribution.
+Plone packages require that you include a change log entry or news item with your contribution.
 This is enforced by continuous integration through GitHub Actions.
 
 Plone uses [`towncrier`](https://github.com/collective/zestreleaser.towncrier) to manage change log entries and to automatically generate history or change log files from the entries.
-The log file is usually named `CHANGES.rst`, `CHANGES.md`, or `CHANGELOG.md`, and is located at the root of the project.
-When a project is released with a new version, the release manager runs `towncrier` as part of the release process.
+The log file is usually named `CHANGES.rst`, `CHANGES.md`, or `CHANGELOG.md`, and is located at the root of the package.
+When a package is released with a new version, the release manager runs `towncrier` as part of the release process.
 Because the log file is automatically generated, you should not edit it directly, except to make corrections, such as broken links.
 
-To create a change log entry or news item, create a file that is placed in the root of the repository directory at `/news`.
+To create a change log entry or news item, create a file in the `news` directory, located in the root of the package.
 Its format must be `###.type`, where `###` is the referenced GitHub issue or pull request number, `.` is the literal extension delimiter, and `type` is one of the following strings.
 
 -   `breaking` for breaking changes
@@ -88,7 +88,7 @@ Its format must be `###.type`, where `###` is the referenced GitHub issue or pul
 -   `feature` for new features
 -   `internal` for internal changes
 
-A project configures the types it allows in a file `towncrier.toml` located at the root of its repository.
+A package configures the types it allows in a file `towncrier.toml` located at the root of its package directory.
 
 The content of this file must include the following.
 
@@ -98,7 +98,7 @@ The content of this file must include the following.
 The following text is an example change log entry, placed inside {file}`/news/4569.documentation`.
 
 ```text
-Fix broken links for ReactJS.org. @stevepiercy
+Fixed broken links for ReactJS.org. @stevepiercy
 ```
 
 (contributing-project-configuration-files-label)=


### PR DESCRIPTION
We omitted licenses used for Documentation, Training, and Volto.

Volto moved to a monorepo, and its news path changed. Also, technically speaking, only packages, not projects, have releases with change log entries.

This PR corrects all these issues.