### PR TITLE
Move Vale from a manual installation to pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,8 +196,8 @@ linkcheckbroken: deps  ## Run linkcheck and show only broken links
 
 .PHONY: vale
 vale: deps  ## Run Vale style, grammar, and spell checks
-	vale sync
-	vale --no-wrap $(VALEFILES)
+	bin/vale sync
+	bin/vale --no-wrap $(VALEFILES)
 	@echo
 	@echo "Vale is finished; look for any errors in the above output."
 

--- a/docs/contributing/documentation/authors.md
+++ b/docs/contributing/documentation/authors.md
@@ -53,15 +53,12 @@ Open `/_build/html/index.html` in a web browser.
 
 ### American English spelling, grammar, and syntax, and style guide
 
-Spellings are enforced through [`Vale`](https://vale.sh/).
+[Vale](https://vale.sh/) is a linter for narrative text.
+It checks spelling, English grammar, and style guides.
 Plone uses American English.
 
-Spelling is configured in {file}`Makefile`, {file}`.vale.ini`, and in files in `styles/Vocab/Plone/`.
-
-Authors should add new words and proper names using correct casing to {file}`styles/Vocab/Plone/accept.txt`, sorted alphabetically and case-insensitive.
-
 Vale also provides English grammar and syntax checking, as well as a Style Guide.
-We follow the [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).
+The Plone Documentation Team selected the [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/) for its ease of use—especially for non-native English readers and writers—and attention to non-technical audiences. 
 
 To perform all these checks, run the following command.
 
@@ -73,6 +70,41 @@ Because it is difficult to automate good American English grammar and syntax, we
 We also understand that contributors might not be fluent in English.
 We encourage contributors to make a reasonable effort, and to request a review of their pull request from community members who are fluent in English to fix grammar and syntax.
 Please ask!
+
+```{note}
+More corrections to spellings and Vale's configuration are welcome by submitting a pull request.
+This is an easy way to become a contributor to Plone.
+See {ref}`authors-advanced-vale-usage-label` for details.
+```
+
+
+(authors-advanced-vale-usage-label)=
+
+#### Advanced Vale usage
+
+To have Vale check only a specific file or directory of files, you can issue [Vale commands](https://vale.sh/manual/) with options in a shell session.
+To allow this, you must either:
+
+-   activate your Python virtual environment
+-   use the virtual environment path, such as `bin/vale`
+-   install Vale using operating system's package manager
+
+The Vale `Makefile` command automatically installs Vale into your Python virtual environment—which is also created via any documentation `Makefile` commands—when you invoke it for the first time.
+
+Vale has [integrations](https://vale.sh/docs/integrations/guide/) with various IDEs.
+Integration might require installing Vale using operating system's package manager.
+
+-   [JetBrains](https://vale.sh/docs/integrations/jetbrains/)
+-   [Vim](https://github.com/dense-analysis/ale)
+-   [VS Code](https://github.com/errata-ai/vale-vscode)
+
+Plone configures Vale in three places:
+
+-   {file}`.vale.ini` is Vale's configuration file.
+    This file allows overriding rules or changing their severity.
+-   {file}`Makefile` passes options to the `vale` command, such as the files Vale checks.
+-   Plone documentation uses a custom spelling dictionary, with accepted and rejected spellings in `styles/Vocab/Plone`.
+    Authors should add new words and proper names using correct casing to {file}`styles/Vocab/Plone/accept.txt`, sorted alphabetically and case-insensitive.
 
 
 (authors-linkcheck-label)=

--- a/docs/contributing/documentation/setup-build.md
+++ b/docs/contributing/documentation/setup-build.md
@@ -30,33 +30,6 @@ A more recent Python is preferred.
 Use your system's package manager or [pyenv](https://github.com/pyenv/pyenv) to install an appropriate version of Python.
 
 
-(setup-build-installation-vale-label)=
-
-### Vale
-
-Vale is a linter for narrative text.
-It checks spelling, English grammar, and style guides.
-Plone documentation uses a custom spelling dictionary, with accepted and rejected spellings in `styles/Vocab/Plone`.
-
-Use your operating system's package manager to [install Vale](https://vale.sh/docs/vale-cli/installation/).
-
-Vale also has [integrations](https://vale.sh/docs/integrations/guide/) with various IDEs.
-
--   [JetBrains](https://vale.sh/docs/integrations/jetbrains/)
--   [Vim](https://github.com/dense-analysis/ale)
--   [VS Code](https://github.com/errata-ai/vale-vscode)
-
-Plone documentation uses a file located at the root of the repository, `.vale.ini`, to configure Vale.
-This file allows overriding rules or changing their severity.
-
-The Plone Documentation Team selected the [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/) for its ease of use—especially for non-native English readers and writers—and attention to non-technical audiences. 
-
-```{note}
-More corrections to spellings and Vale's configuration are welcome by submitting a pull request.
-This is an easy way to become a contributor to Plone.
-```
-
-
 (setup-build-installation-graphviz-label)=
 
 ### Graphviz

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sphinxcontrib.httpdomain  # plone.restapi
 sphinxcontrib.httpexample  # plone.restapi
 sphinxcontrib-video
 sphinxext-opengraph
+vale


### PR DESCRIPTION
- Move Vale from a manual installation to pip
- Move the install and configuration documentation of Vale to `authors.md`.

Thanks to https://github.com/daniperez/vale-python-package, and a [quickly merged pull request](https://github.com/daniperez/vale-python-package/pull/29), we now have this option.