### PR TITLE
Use includes for installation of prerequisites

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,7 @@ exclude_patterns = [
     "plone.restapi/performance",
     "plone.restapi/src",
     "volto/contributing/branch-policy.md",
+    "volto/contributing/install-operating-system.md",
     "volto/contributing/install-nodejs.md",
     "volto/contributing/install-make.md",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,6 @@ exclude_patterns = [
     "plone.restapi/performance",
     "plone.restapi/src",
     "volto/contributing/branch-policy.md",
-    "volto/contributing/install-nvm.md",
     "volto/contributing/install-nodejs.md",
     "volto/contributing/install-make.md",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,9 @@ exclude_patterns = [
     "plone.restapi/performance",
     "plone.restapi/src",
     "volto/contributing/branch-policy.md",
+    "volto/contributing/install-nvm.md",
+    "volto/contributing/install-nodejs.md",
+    "volto/contributing/install-make.md",
 ]
 
 suppress_warnings = [

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -671,4 +671,7 @@ intid
 WSL
 Windows Subsystem for Linux
     The [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lets developers install a Linux distribution (such as Ubuntu, OpenSUSE, Kali, Debian, or Arch Linux) and use Linux applications, utilities, and Bash command-line tools directly on Windows, unmodified, without the overhead of a traditional virtual machine or dualboot setup.
+
+pnpm
+    [pnpm](https://pnpm.io/) is a fast, disk space efficient package manager.
 ```

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -11,7 +11,9 @@ myst:
 
 # Install
 
-In this part of the documentation, you can find how to try Plone and how to choose an installation method if you want to develop in Plone.
+In this part of the documentation, you can find how to try Plone and how to choose an installation method for developing a project using Plone.
+
+For developing Plone and its packages as open source software contributions, see the package's contributing guide.
 
 
 (install-index-getting-started-label)=

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -51,14 +51,8 @@ To avoid RAM and disk swap limitations, we recommend either temporarily resizing
 
 ### Pre-requisites for installation
 
--   An operating system that runs all the requirements mentioned above.
-    Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or {term}`Windows Subsystem for Linux` (WSL) on Windows.
-    A UNIX-based operating system is recommended.
-
-    ```{important}
-    Windows alone is not recommended because it does not support {term}`GNU make`.
-    If you get Plone to run on Windows alone, please feel free to document and share your process.
-    ```
+```{include} ../volto/contributing/install-operating-system.md
+```
 
 -   Python {SUPPORTED_PYTHON_VERSIONS}
 -   {term}`pipx`

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -93,7 +93,7 @@ Adapt them for your flavor of shell.
 
 ```{seealso}
 See the [`nvm` install and update script documentation](https://github.com/nvm-sh/nvm#install--update-script).
-For the `fish` shell, see [`nvm.fish`](https://github.com/joxji/nvm.fish).
+For the `fish` shell, see [`nvm.fish`](https://github.com/jorgebucaran/nvm.fish).
 ```
 
 1.  Create your shell profile, if it does not exist.

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -184,12 +184,13 @@ Install the latest Yarn 3 version (not the Classic 1.x one) using `npm`.
 ```{include} ../volto/contributing/install-make.md
 ```
 
+
 (install-prerequisites-docker-label)=
 
 #### Install Docker
 
-Install [Docker Desktop](https://docs.docker.com/get-docker/) for your operating system.
-Docker Desktop includes all Docker tools.
+```{include} ../volto/contributing/install-docker.md
+```
 
 
 (install-packages-install-label)=

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -94,8 +94,38 @@ pip install pipx
 
 #### nvm
 
-```{include} ../volto/contributing/install-nvm.md
+The following terminal session commands use `bash` for the shell.
+Adapt them for your flavor of shell.
+
+```{seealso}
+See the [`nvm` install and update script documentation](https://github.com/nvm-sh/nvm#install--update-script).
+For the `fish` shell, see [`nvm.fish`](https://github.com/joxji/nvm.fish).
 ```
+
+1.  Create your shell profile, if it does not exist.
+
+    ```shell
+    touch ~/.bash_profile
+    ```
+
+2.  Download and run the `nvm` install and update script, and pipe it into `bash`.
+
+    ```shell
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v{NVM_VERSION}/install.sh | bash
+    ```
+
+3.  Source your profile.
+    Alternatively close the session and open a new one.
+
+    ```shell
+    source ~/.bash_profile
+    ```
+
+4.  Verify that the `nvm` version is that which you just installed or updated:
+
+    ```shell
+    nvm --version
+    ```
 
 
 (install-prerequisites-nodejs-label)=

--- a/docs/install/install-from-packages.md
+++ b/docs/install/install-from-packages.md
@@ -94,56 +94,16 @@ pip install pipx
 
 #### nvm
 
-The following terminal session commands use `bash` for the shell.
-Adapt them for your flavor of shell.
-
-```{seealso}
-See the [`nvm` install and update script documentation](https://github.com/nvm-sh/nvm#install--update-script).
-For the `fish` shell, see [`nvm.fish`](https://github.com/joxji/nvm.fish).
+```{include} ../volto/contributing/install-nvm.md
 ```
-
-1.  Create your shell profile, if it does not exist.
-
-    ```shell
-    touch ~/.bash_profile
-    ```
-
-2.  Download and run the `nvm` install and update script, and pipe it into `bash`.
-
-    ```shell
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v{NVM_VERSION}/install.sh | bash
-    ```
-
-3.  Source your profile.
-    Alternatively close the session and open a new one.
-
-    ```shell
-    source ~/.bash_profile
-    ```
-
-4.  Verify that the `nvm` version is that which you just installed or updated:
-
-    ```shell
-    nvm --version
-    ```
 
 
 (install-prerequisites-nodejs-label)=
 
 #### Node.js
 
-1.  Install or update the supported LTS versions of Node.js, then activate the version supported in Volto.
-
-    ```shell
-    nvm install "lts/*"
-    nvm use 20
-    ```
-
-2.  Verify that the supported version of Node.js is activated.
-
-    ```shell
-    node -v
-    ```
+```{include} ../volto/contributing/install-nodejs.md
+```
 
 
 (install-prerequisites-yeoman-label)=
@@ -185,25 +145,20 @@ Install the latest Yarn 3 version (not the Classic 1.x one) using `npm`.
     ```
 
     If the version doesn't change, you can try deleting the {file}`yarn.lock` file, setting the version, and installing again.
+
     ```shell
     rm yarn.lock
     yarn set version 3.x
     yarn install
     ```
-    
 
 
 (install-prerequisites-make-label)=
 
 #### Make
 
-{term}`Make` comes installed on most Linux distributions.
-On macOS, you must first [install Xcode](https://developer.apple.com/xcode/resources/), then install its command line tools.
-On Windows, it is strongly recommended to [Install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install), which will include `make`.
-
-Finally, it is a good idea to update your system's version of `make`, because some distributions, especially macOS, have an outdated version.
-Use your favorite search engine or trusted online resource for how to update `make`.
-
+```{include} ../volto/contributing/install-make.md
+```
 
 (install-prerequisites-docker-label)=
 


### PR DESCRIPTION
This PR must be merged immediately after https://github.com/plone/volto/pull/5564 is merged and the git submodule tip for volto is updated.

The purpose of this PR is to avoid copy-pasta and drifting installation instructions. Further centralization may be needed.

See also https://github.com/plone/volto/issues/3289.