### PR TITLE
Fixed a small typo error

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/new-issue-form.yml
@@ -17,6 +17,6 @@ body:
     id: description
     attributes:
       label: Description
-      description: Include include screenshots and any other helpful information.
+      description: Include screenshots and any other helpful information.
     validations:
       required: true


### PR DESCRIPTION
 Fixes #1613 

## Description

Made this statement: "Include include screenshots and any other helpful information." grammatically correct.



