### PR TITLE
Fix Directory Path Handling in Makefile for Compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ SPHINXOPTS      ?=
 PAPER           ?=
 
 # Internal variables.
-SPHINXBUILD     = $(realpath bin/sphinx-build)
-SPHINXAUTOBUILD = $(realpath bin/sphinx-autobuild)
+SPHINXBUILD     = "$(realpath bin/sphinx-build)"
+SPHINXAUTOBUILD = "$(realpath bin/sphinx-autobuild)"
 DOCS_DIR        = ./docs/
 BUILDDIR        = ../_build
 PAPEROPT_a4     = -D latex_paper_size=a4


### PR DESCRIPTION
Issue Description:
The Makefile uses realpath to set SPHINXBUILD and SPHINXAUTOBUILD:
```
SPHINXBUILD     = $(realpath bin/sphinx-build)
SPHINXAUTOBUILD = $(realpath bin/sphinx-autobuild)
```
This can cause compatibility issues and doesn't handle special characters in paths. We need to replace realpath with a more portable and robust method. This issues was already discussed with @stevepiercy on plone community [conversation link](https://community.plone.org/t/error-running-training-repo-seek-advice-on-pull-request/18618/8?u=vivek-04022001) 

I, Vivek Kumar, agree to have this contribution published under Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.


I humbly request the merging of this pull request as my Plone Contributor Agreement is currently undergoing some changes. Your assistance is greatly appreciated.