### PR TITLE
Bump the linkcheck timeout to 10 seconds from 5.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ linkcheck_ignore = [
     r"https://www.youtube.com/playlist",  # volto, TODO remove after installing sphinxcontrib.youtube
 ]
 linkcheck_anchors = True
-linkcheck_timeout = 5
+linkcheck_timeout = 10
 linkcheck_retries = 1
 
 # The suffix of source filenames.


### PR DESCRIPTION
https://github.com/zopefoundation/z3c.form/tree/master/src/z3c/form/browser takes about 8 seconds to load. The longer timeout should allow it to pass going forward.

Fixes #1612.