### PR TITLE
Improve docs for classicui-images: direction parameter

### DIFF
--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -237,6 +237,10 @@ image_scale = scaling_util.publishTraverse(context.REQUEST, groups[1])
 
 ## Scaling `direction`
 
+```{versionchanged} 6.0
+Added new option names to align with CSS `background-size` values, and deprecated previous names.
+```
+
 Scaling is intended for the optimal display of images in a web browser.
 
 To scale an image, you can use the `direction` parameter to control the scaling output.

--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -114,7 +114,7 @@ tag = scale_util.tag(
     scale=None,
     height=None,
     width=None,
-    direction="thumbnail"
+    mode="scale"
 )
 ```
 
@@ -233,9 +233,9 @@ image_scale = scaling_util.publishTraverse(context.REQUEST, groups[1])
 ```
 
 
-(classic-ui-images-scaling-direction-label)=
+(classic-ui-images-scaling-mode-label)=
 
-## Scaling `direction`
+## Scaling `mode`
 
 ```{versionchanged} 6.0
 Added new option names to align with CSS `background-size` values, and deprecated previous names.
@@ -243,13 +243,13 @@ Added new option names to align with CSS `background-size` values, and deprecate
 
 Scaling is intended for the optimal display of images in a web browser.
 
-To scale an image, you can use the `direction` parameter to control the scaling output.
+To scale an image, you can use the `mode` parameter to control the scaling output.
 You must use either `width` or `height`, or both.
 
 Three different scaling options are supported.
 They correspond to the CSS [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) values.
 
-The possible options for `direction` are listed below, where the default option is `scale`.
+The possible options for `mode` are listed below, where the default option is `scale`.
 
 `scale`
 :   This is the default option.

--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -237,36 +237,36 @@ image_scale = scaling_util.publishTraverse(context.REQUEST, groups[1])
 
 ## Scaling `direction`
 
-If an images is scaled the direction parameter can be used to control the scaling output.
-Either width or height - or both - must be given too.
+Scaling is intended for the optimal display of images in a web browser.
 
-This is all about scaling for the display in a web browser.
+To scale an image, you can use the `direction` parameter to control the scaling output.
+You must use either `width` or `height`, or both.
 
 Three different scaling options are supported.
-They correspond to the CSS background-size values (see [background-size documentation of mdn web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size))
+They correspond to the CSS [`background-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) values.
 
-The default direction is `scale`.
+The possible options for `direction` are listed below, where the default option is `scale`.
 
-Possible options are:
+`scale`
+:   This is the default option.
+    `scale` scales to the requested dimensions without cropping.
+    The resulting image may have a different size than requested.
+    This option requires both `width` and `height` to be specified.
+    It does not scale up.
 
-* `scale`:
-  Scales to the requested dimensions without cropping.
-  The resulting image may have a different size than requested.
-  This option requires both width and height to be specified.
-  Does not scale up.
+    Deprecated spellings: `keep`, `thumbnail`.
 
-  Deprecated spellings: `keep`, `thumbnail`.
+`contain`
+:   `contain` starts by scaling the image either to the smaller dimension when you give both `width` and `height`, or to the only given dimension, then crops to the other dimension if needed.
 
-* `contain`:
-  Starts by scaling the relatively smallest dimension to the required size and crops the other dimension if needed.
+    Deprecated spellings: `scale-crop-to-fit`, `down`.
 
-  Deprecated spellings: `scale-crop-to-fit`, `down`.
+`cover`
+:   `cover` scales the image either to the larger dimension when you give both `width` and `height`, or to the only given dimension, up to the size you specify.
+    Despite the deprecated spelling, it does not crop.
 
-* `cover`:
-  Scales the relatively largest dimension up to the required size.
-  Despite the deprecated spelling, there is no cropping happening.
+    Deprecated spellings: `scale-crop-to-fill`, `up`.
 
-  Deprecated spellings: `scale-crop-to-fill`, `up`.
 
 (classic-ui-images-permissions-label)=
 

--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -237,17 +237,36 @@ image_scale = scaling_util.publishTraverse(context.REQUEST, groups[1])
 
 ## Scaling `direction`
 
-The default direction is `thumbnail`.
+If an images is scaled the direction parameter can be used to control the scaling output.
+Either width or height - or both - must be given too.
 
-Other options are:
+This is all about scaling for the display in a web browser.
 
-* `down`
-* `keep`
-* `scale-crop-to-fill`
-* `scale-crop-to-fit`
-* `thumbnail`
-* `up`
+Three different scaling options are supported.
+They correspond to the CSS background-size values (see [background-size documentation of mdn web docs](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size))
 
+The default direction is `scale`.
+
+Possible options are:
+
+* `scale`:
+  Scales to the requested dimensions without cropping.
+  The resulting image may have a different size than requested.
+  This option requires both width and height to be specified.
+  Does not scale up.
+
+  Deprecated spellings: `keep`, `thumbnail`.
+
+* `contain`:
+  Starts by scaling the relatively smallest dimension to the required size and crops the other dimension if needed.
+
+  Deprecated spellings: `scale-crop-to-fit`, `down`.
+
+* `cover`:
+  Scales the relatively largest dimension up to the required size.
+  Despite the deprecated spelling, there is no cropping happening.
+
+  Deprecated spellings: `scale-crop-to-fill`, `up`.
 
 (classic-ui-images-permissions-label)=
 

--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -238,7 +238,8 @@ image_scale = scaling_util.publishTraverse(context.REQUEST, groups[1])
 ## Scaling `mode`
 
 ```{versionchanged} 6.0
-Added new option names to align with CSS `background-size` values, and deprecated previous names.
+Added `mode` to replace the deprecated `direction`.
+Added new option names for `mode` to align with CSS `background-size` values, and deprecated previous names `keep`, `thumbnail`, `scale-crop-to-fit`, `down`, `scale-crop-to-fill`, and `up`.
 ```
 
 Scaling is intended for the optimal display of images in a web browser.

--- a/docs/classic-ui/images.md
+++ b/docs/classic-ui/images.md
@@ -254,18 +254,18 @@ The possible options for `direction` are listed below, where the default option 
     This option requires both `width` and `height` to be specified.
     It does not scale up.
 
-    Deprecated spellings: `keep`, `thumbnail`.
+    Deprecated option names: `keep`, `thumbnail`.
 
 `contain`
 :   `contain` starts by scaling the image either to the smaller dimension when you give both `width` and `height`, or to the only given dimension, then crops to the other dimension if needed.
 
-    Deprecated spellings: `scale-crop-to-fit`, `down`.
+    Deprecated option names: `scale-crop-to-fit`, `down`.
 
 `cover`
 :   `cover` scales the image either to the larger dimension when you give both `width` and `height`, or to the only given dimension, up to the size you specify.
-    Despite the deprecated spelling, it does not crop.
+    Despite the deprecated option name, it does not crop.
 
-    Deprecated spellings: `scale-crop-to-fill`, `up`.
+    Deprecated option names: `scale-crop-to-fill`, `up`.
 
 
 (classic-ui-images-permissions-label)=


### PR DESCRIPTION
Scaling direction docs were incomplete. I took the notes from https://github.com/plone/plone.scale/blob/master/plone/scale/scale.py#L402-L433 and turned them into some more doc-like.

The alternative spelling are in fact kind of deprecated. they still work and are all over the code, but we want people to use the new terms to reduce confusion.