### PR TITLE
Add Mockup landing page to docs

### DIFF
--- a/docs/classic-ui/index.md
+++ b/docs/classic-ui/index.md
@@ -53,6 +53,7 @@ forms
 icons
 images
 layers
+mockup
 portlets
 recipes
 static-resources

--- a/docs/classic-ui/mockup.md
+++ b/docs/classic-ui/mockup.md
@@ -1,0 +1,18 @@
+---
+myst:
+  html_meta:
+    "description": "Mockup together with Patternslib are used to create Classic UI, a frontend for Plone."
+    "property=og:description": "Mockup together with Patternslib are used to create Classic UI, a frontend for Plone."
+    "property=og:title": "Mockup"
+    "keywords": "Mockup, Patternslib, Classic UI, frontend, Plone"
+---
+
+(mockup-label)=
+
+# Mockup
+
+{term}`Mockup` together with {term}`Patternslib` are used to create {term}`Classic UI`, a frontend for Plone.
+
+View a [demo of Mockup](https://plone.github.io/mockup/).
+
+For more information, visit the [Mockup repository on GitHub](https://github.com/plone/mockup).

--- a/docs/classic-ui/mockup.md
+++ b/docs/classic-ui/mockup.md
@@ -1,8 +1,8 @@
 ---
 myst:
   html_meta:
-    "description": "Mockup together with Patternslib building the UI toolkit for Classic UI, a frontend for Plone."
-    "property=og:description": "Mockup together with Patternslib building the UI toolkit for Classic UI, a frontend for Plone."
+    "description": "Mockup together with Patternslib are used to build the UI toolkit for Classic UI, a frontend for Plone."
+    "property=og:description": "Mockup together with Patternslib are used to build the UI toolkit for Classic UI, a frontend for Plone."
     "property=og:title": "Mockup"
     "keywords": "Mockup, Patternslib, Classic UI, frontend, Plone"
 ---
@@ -11,7 +11,7 @@ myst:
 
 # Mockup
 
-{term}`Mockup` together with {term}`Patternslib` building the UI toolkit for {term}`Classic UI`, a frontend for Plone.
+{term}`Mockup` together with {term}`Patternslib` are used to build the UI toolkit for {term}`Classic UI`, a frontend for Plone.
 
 View the [interactive documentation of Mockup](https://plone.github.io/mockup/).
 

--- a/docs/classic-ui/mockup.md
+++ b/docs/classic-ui/mockup.md
@@ -1,8 +1,8 @@
 ---
 myst:
   html_meta:
-    "description": "Mockup together with Patternslib are used to create Classic UI, a frontend for Plone."
-    "property=og:description": "Mockup together with Patternslib are used to create Classic UI, a frontend for Plone."
+    "description": "Mockup together with Patternslib building the UI toolkit for Classic UI, a frontend for Plone."
+    "property=og:description": "Mockup together with Patternslib building the UI toolkit for Classic UI, a frontend for Plone."
     "property=og:title": "Mockup"
     "keywords": "Mockup, Patternslib, Classic UI, frontend, Plone"
 ---
@@ -11,8 +11,8 @@ myst:
 
 # Mockup
 
-{term}`Mockup` together with {term}`Patternslib` are used to create {term}`Classic UI`, a frontend for Plone.
+{term}`Mockup` together with {term}`Patternslib` building the UI toolkit for {term}`Classic UI`, a frontend for Plone.
 
-View a [demo of Mockup](https://plone.github.io/mockup/).
+View the [interactive documentation of Mockup](https://plone.github.io/mockup/).
 
 For more information, visit the [Mockup repository on GitHub](https://github.com/plone/mockup).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -411,7 +411,7 @@ Classic UI
     The other frontend is {term}`Volto`.
 
 Mockup
-    [Mockup](https://github.com/plone/mockup/) is a package that, together with {term}`Patternslib`, builds the UI toolkit for  {term}`Classic UI`, a frontend for Plone.
+    [Mockup](https://github.com/plone/mockup/) is a package that, together with {term}`Patternslib`, builds the UI toolkit for {term}`Classic UI`, a frontend for Plone.
     Mockup provides the JavaScript stack for Classic UI.
     [View Mockup's patterns](https://plone.github.io/mockup/), based on Patternslib.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -411,7 +411,7 @@ Classic UI
     The other frontend is {term}`Volto`.
 
 Mockup
-    [Mockup](https://github.com/plone/mockup/) is a package that, together with {term}`Patternslib`, are used to create {term}`Classic UI`, a frontend for Plone.
+    [Mockup](https://github.com/plone/mockup/) is a package that, together with {term}`Patternslib`, builds the UI toolkit for  {term}`Classic UI`, a frontend for Plone.
     Mockup provides the JavaScript stack for Classic UI.
     [View Mockup's patterns](https://plone.github.io/mockup/), based on Patternslib.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -406,10 +406,20 @@ Classic UI
     It is integrated with [Products.CMFPlone](https://github.com/plone/Products.CMFPlone/).
     Its theme is named [Barceloneta](https://github.com/plone/plonetheme.barceloneta/).
     It is based on Twitter Bootstrap 5.
-    It uses [Mockup](https://github.com/plone/mockup/) as its JavaScript stack.
-    [View Mockup's patterns](https://plone.github.io/mockup/).
+    It uses {term}`Mockup` as its JavaScript stack.
 
     The other frontend is {term}`Volto`.
+
+Mockup
+    [Mockup](https://github.com/plone/mockup/) is a package that, together with {term}`Patternslib`, are used to create {term}`Classic UI`, a frontend for Plone.
+    Mockup provides the JavaScript stack for Classic UI.
+    [View Mockup's patterns](https://plone.github.io/mockup/), based on Patternslib.
+
+Patterns
+Patternslib
+    [Patterns](https://patternslib.com/), or Patternslib, is a toolkit that enables designers to build rich interactive prototypes without the need for writing any JavaScript.
+    All functionality is triggered by classes and other attributes in the HTML, without abusing the HTML as a programming language.
+    Accessibility, SEO, and well-structured HTML are core values of Patterns.
 
 Slate
     [Slate.js](https://docs.slatejs.org/) is a highly customizable platform for creating rich-text editors, also known as `WYSIWYG` editors.


### PR DESCRIPTION
Supersedes and closes #1548.

This is the first version of the Mockup landing page. Once @fredvd has completed GitHub workflow work to synch the mockup demo to https://6.docs.plone.org/mockup, then I will update links accordingly.