### PR TITLE
Fix for plone/cookiecutter-zope-instance 2.x: naming zcml variables

### DIFF
--- a/docs/install/manage-add-ons-packages.md
+++ b/docs/install/manage-add-ons-packages.md
@@ -173,8 +173,7 @@ collective.easyform
 
 Add it to {file}`instance.yaml` to let Zope know that this add-on should be loaded:
 
-```{code-block} yaml
-:emphasize-lines: 3-6
+```yaml
 default_context:
     zcml_package_includes: project_title, collective.easyform
 ```

--- a/docs/install/manage-add-ons-packages.md
+++ b/docs/install/manage-add-ons-packages.md
@@ -176,11 +176,7 @@ Add it to {file}`instance.yaml` to let Zope know that this add-on should be load
 ```{code-block} yaml
 :emphasize-lines: 3-6
 default_context:
-    load_zcml:
-        package_includes: [
-            'project_title',
-            'collective.easyform',
-        ]
+    zcml_package_includes: project_title, collective.easyform
 ```
 
 Stop the backend with {kbd}`ctrl-c`.
@@ -221,11 +217,7 @@ Add it to {file}`instance.yaml` to let Zope know that this add-on should be load
 
 ```yaml
 default_context:
-    load_zcml:
-        package_includes: [
-            'project_title',
-            'collective.easyform',
-        ]
+    zcml_package_includes: project_title, collective.easyform
 ```
 
 Stop the backend with {kbd}`ctrl-c`.
@@ -265,11 +257,7 @@ Add it to {file}`instance.yaml` to let Zope know that this add-on should be load
 
 ```yaml
 default_context:
-    load_zcml:
-        package_includes: [
-            'project_title',
-            'collective.easyform',
-        ]
+    zcml_package_includes: project_title, collective.easyform
 ```
 
 Stop the backend with {kbd}`ctrl-c`.


### PR DESCRIPTION
See https://github.com/plone/cookiecutter-zope-instance?tab=readme-ov-file#upgrading

Fix needed. Otherwise the build (`make build-backend`) fails.