### PR TITLE
Add Viewlets section to 6.0 backend upgrade guide.

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/index.md
+++ b/docs/backend/upgrading/version-specific-migration/index.md
@@ -27,4 +27,5 @@ upgrade-to-python3
 upgrade-zodb-to-python3
 upgrade-to-60
 migrate-to-volto
+changelog
 ```

--- a/docs/backend/upgrading/version-specific-migration/index.md
+++ b/docs/backend/upgrading/version-specific-migration/index.md
@@ -27,5 +27,4 @@ upgrade-to-python3
 upgrade-zodb-to-python3
 upgrade-to-60
 migrate-to-volto
-changelog
 ```

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -608,7 +608,7 @@ See also the [TinyMCE 4 to 5 upgrade guide](https://www.tiny.cloud/docs/migratio
 Plone 6.0 renames various viewlets or moves them to a different viewlet manager.
 This is because some viewlet names contained the name of a viewlet manager.
 This didn't always match the name of their actual viewlet manager, especially after moving them.
-Plone 6.0 removes such references from the viewlet names, to avoid confusion.
+Plone 6.0 removes such references from the viewlet names to avoid confusion.
 
 - Plone 6.0 removes the `plone.documentactions (IDocumentActions)`  viewlet manager. In Plone 5.2 it was already empty.
 - Plone 6.0 adds the `plone.belowcontentdescription (IBelowContentDescription)` viewlet manager. By default this has no viewlets.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -606,7 +606,7 @@ See also the [TinyMCE 4 to 5 upgrade guide](https://www.tiny.cloud/docs/migratio
 ## Viewlets
 
 Plone 6.0 renames various viewlets or moves them to a different viewlet manager.
-The reason for renaming, is that some viewlet names contained the name of a viewlet manager.
+This is because some viewlet names contained the name of a viewlet manager.
 This didn't always match the name of their actual viewlet manager, especially after moving them.
 Plone 6.0 removes such references from the viewlet names, to avoid confusion.
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -625,9 +625,6 @@ Plone 6.0 removes such references from the viewlet names to avoid confusion.
     It remains in manager `plone.belowcontenttitle`.
 -   Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords`, and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
 -   Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
--   Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`.
-    The viewlet remains in manager `plone.portalfooter`.
-    It renders the portlets from the `plone.footerportlets` portlet manager.
 
 This is the same information in table form.
 You can toggle navigation to make more of the table visible.
@@ -647,3 +644,7 @@ You can toggle navigation to make more of the table visible.
 | `plone.belowcontenttitle.keywords` | `plone.belowcontent` | `plone.keywords` | `plone.belowcontentbody` |
 | | `plone.belowcontentbody` | `plone.rights` | `plone.belowcontentbody` |
 ```
+
+One final change is that Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`.
+The viewlet remains in manager `plone.portalfooter`.
+It renders the portlets from the `plone.footerportlets` portlet manager.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -628,7 +628,7 @@ Plone 6.0 removes such references from the viewlet names to avoid confusion.
 
 The names in the following table have had the namespace `plone.` removed from them for display purposes only.
 In your code, you should use the object's `plone.` namespace as a prefix.
-This table show the same information, but in table form.
+This table shows the same information, but in tabular form.
 You can toggle navigation to make more of the table visible.
 
 ```{table} Viewlet changes from 5.2 to 6.0

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -617,7 +617,7 @@ Plone 6.0 removes such references from the viewlet names to avoid confusion.
 - Plone 6.0 renames the `plone.abovecontenttitle.socialtags` viewlet to `plone.socialtags`. It remains in manager `plone.abovecontenttitle`.
 - Plone 6.0 renames the `plone.belowcontentbody.relateditems` viewlet to `plone.relateditems`. It remains in manager `plone.belowcontentbody`.
 - Plone 6.0 removes the `plone.manage_portlets_fallback` viewlet from the `plone.belowcontent` manager.
-- Plone 6.0 renames the `plone.belowcontenttitle.documentbyline` viewlet to `plone.documentbyline` . It remains in manager `plone.belowcontenttitle`.
+- Plone 6.0 renames the `plone.belowcontenttitle.documentbyline` viewlet to `plone.documentbyline`. It remains in manager `plone.belowcontenttitle`.
 - Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords` and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
 - Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
 - Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`. The viewlet remains in manager `plone.portalfooter`. It renders the portlets from the `plone.footerportlets` portlet manager.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -610,7 +610,7 @@ This is because some viewlet names contained the name of a viewlet manager.
 This didn't always match the name of their actual viewlet manager, especially after moving them.
 Plone 6.0 removes such references from the viewlet names to avoid confusion.
 
-- Plone 6.0 removes the `plone.documentactions (IDocumentActions)`  viewlet manager. In Plone 5.2 it was already empty.
+- Plone 6.0 removes the `plone.documentactions (IDocumentActions)` viewlet manager. In Plone 5.2 it was already empty.
 - Plone 6.0 adds the `plone.belowcontentdescription (IBelowContentDescription)` viewlet manager. By default this has no viewlets.
 - Plone 6.0 removes the `plone.header` viewlet from `plone.portaltop` manager, making it empty.
 - Plone 6.0 renames the `plone.abovecontenttitle.documentactions` viewlet to `plone.documentactions` and moves it from manager `plone.belowcontentbody` to `plone.belowcontent`.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -602,3 +602,40 @@ Please make sure you write valid JSON for the `template` option.
 ```{seealso}
 See also the [TinyMCE 4 to 5 upgrade guide](https://www.tiny.cloud/docs/migration-from-4x/).
 ```
+
+## Viewlets
+
+Plone 6.0 renames various viewlets or moves them to a different viewlet manager.
+The reason for renaming, is that some viewlet names contained the name of a viewlet manager.
+This didn't always match the name of their actual viewlet manager, especially after moving them.
+Plone 6.0 removes such references from the viewlet names, to avoid confusion.
+
+- Plone 6.0 removes the `plone.documentactions (IDocumentActions)`  viewlet manager. In Plone 5.2 it was already empty.
+- Plone 6.0 adds the `plone.belowcontentdescription (IBelowContentDescription)` viewlet manager. By default this has no viewlets.
+- Plone 6.0 removes the `plone.header` viewlet from `plone.portaltop` manager, making it empty.
+- Plone 6.0 renames the `plone.abovecontenttitle.documentactions` viewlet to `plone.documentactions` and moves it from manager `plone.belowcontentbody` to `plone.belowcontent`.
+- Plone 6.0 renames the `plone.abovecontenttitle.socialtags` viewlet to `plone.socialtags`. It remains in manager `plone.abovecontenttitle`.
+- Plone 6.0 renames the `plone.belowcontentbody.relateditems` viewlet to `plone.relateditems`. It remains in manager `plone.belowcontentbody`.
+- Plone 6.0 removes the `plone.manage_portlets_fallback` viewlet from the `plone.belowcontent` manager.
+- Plone 6.0 renames the `plone.belowcontenttitle.documentbyline` viewlet to `plone.documentbyline` . It remains in manager `plone.belowcontenttitle`.
+- Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords` and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
+- Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
+- Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`. The viewlet remains in manager `plone.portalfooter`. It renders the portlets from the `plone.footerportlets` portlet manager.
+
+This is the same information in table form.
+You can toggle navigation to make more of the table visible.
+
+:::{table} Viewlet changes from 5.2 to 6.0
+
+| 5.2 viewlet name | 5.2 viewlet manager | 6.0 viewlet name | 6.0 viewlet manager |
+| ---------------- | ------------------- | ---------------- | ------------------- |
+|| `plone.documentactions` | | |
+|||| `plone.belowcontentdescription` |
+| `plone.header` | `plone.portaltop` | | `plone.portaltop` |
+| `plone.abovecontenttitle.documentactions` | `plone.belowcontentbody` | `plone.documentactions` | `plone.belowcontent` |
+| `plone.abovecontenttitle.socialtags` | `plone.abovecontenttitle` | `plone.socialtags` | `plone.abovecontenttitle` |
+| `plone.belowcontentbody.relateditems` | `plone.belowcontentbody` | `plone.relateditems` | `plone.belowcontentbody` |
+| `plone.manage_portlets_fallback` | `plone.belowcontent` | | `plone.belowcontent` |
+| `plone.belowcontenttitle.documentbyline` | `plone.belowcontenttitle` | `plone.documentbyline` | `plone.belowcontenttitle` |
+| `plone.belowcontenttitle.keywords` | `plone.belowcontent` | `plone.keywords` | `plone.belowcontentbody` |
+| | `plone.belowcontentbody` | `plone.rights` | `plone.belowcontentbody` |

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -610,22 +610,29 @@ This is because some viewlet names contained the name of a viewlet manager.
 This didn't always match the name of their actual viewlet manager, especially after moving them.
 Plone 6.0 removes such references from the viewlet names to avoid confusion.
 
-- Plone 6.0 removes the `plone.documentactions (IDocumentActions)` viewlet manager. In Plone 5.2 it was already empty.
-- Plone 6.0 adds the `plone.belowcontentdescription (IBelowContentDescription)` viewlet manager. By default this has no viewlets.
-- Plone 6.0 removes the `plone.header` viewlet from `plone.portaltop` manager, making it empty.
-- Plone 6.0 renames the `plone.abovecontenttitle.documentactions` viewlet to `plone.documentactions` and moves it from manager `plone.belowcontentbody` to `plone.belowcontent`.
-- Plone 6.0 renames the `plone.abovecontenttitle.socialtags` viewlet to `plone.socialtags`. It remains in manager `plone.abovecontenttitle`.
-- Plone 6.0 renames the `plone.belowcontentbody.relateditems` viewlet to `plone.relateditems`. It remains in manager `plone.belowcontentbody`.
-- Plone 6.0 removes the `plone.manage_portlets_fallback` viewlet from the `plone.belowcontent` manager.
-- Plone 6.0 renames the `plone.belowcontenttitle.documentbyline` viewlet to `plone.documentbyline`. It remains in manager `plone.belowcontenttitle`.
-- Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords` and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
-- Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
-- Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`. The viewlet remains in manager `plone.portalfooter`. It renders the portlets from the `plone.footerportlets` portlet manager.
+-   Plone 6.0 removes the `plone.documentactions` (`IDocumentActions`) viewlet manager.
+    In Plone 5.2 it was already empty.
+-   Plone 6.0 adds the `plone.belowcontentdescription` (`IBelowContentDescription`) viewlet manager.
+    By default this has no viewlets.
+-   Plone 6.0 removes the `plone.header` viewlet from `plone.portaltop` manager, making it empty.
+-   Plone 6.0 renames the `plone.abovecontenttitle.documentactions` viewlet to `plone.documentactions`, and moves it from manager `plone.belowcontentbody` to `plone.belowcontent`.
+-   Plone 6.0 renames the `plone.abovecontenttitle.socialtags` viewlet to `plone.socialtags`.
+    It remains in manager `plone.abovecontenttitle`.
+-   Plone 6.0 renames the `plone.belowcontentbody.relateditems` viewlet to `plone.relateditems`.
+    It remains in manager `plone.belowcontentbody`.
+-   Plone 6.0 removes the `plone.manage_portlets_fallback` viewlet from the `plone.belowcontent` manager.
+-   Plone 6.0 renames the `plone.belowcontenttitle.documentbyline` viewlet to `plone.documentbyline`.
+    It remains in manager `plone.belowcontenttitle`.
+-   Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords`, and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
+-   Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
+-   Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`.
+    The viewlet remains in manager `plone.portalfooter`.
+    It renders the portlets from the `plone.footerportlets` portlet manager.
 
 This is the same information in table form.
 You can toggle navigation to make more of the table visible.
 
-:::{table} Viewlet changes from 5.2 to 6.0
+```{table} Viewlet changes from 5.2 to 6.0
 
 | 5.2 viewlet name | 5.2 viewlet manager | 6.0 viewlet name | 6.0 viewlet manager |
 | ---------------- | ------------------- | ---------------- | ------------------- |
@@ -639,3 +646,4 @@ You can toggle navigation to make more of the table visible.
 | `plone.belowcontenttitle.documentbyline` | `plone.belowcontenttitle` | `plone.documentbyline` | `plone.belowcontenttitle` |
 | `plone.belowcontenttitle.keywords` | `plone.belowcontent` | `plone.keywords` | `plone.belowcontentbody` |
 | | `plone.belowcontentbody` | `plone.rights` | `plone.belowcontentbody` |
+```

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -626,23 +626,25 @@ Plone 6.0 removes such references from the viewlet names to avoid confusion.
 -   Plone 6.0 renames the `plone.belowcontenttitle.keywords` viewlet to `plone.keywords`, and moves it from manager `plone.belowcontent` to `plone.belowcontentbody`.
 -   Plone 6.0 adds the `plone.rights` viewlet in manager `plone.belowcontentbody`.
 
-This is the same information in table form.
+The names in the following table have had the namespace `plone.` removed from them for display purposes only.
+In your code, you should use the object's `plone.` namespace as a prefix.
+This table show the same information, but in table form.
 You can toggle navigation to make more of the table visible.
 
 ```{table} Viewlet changes from 5.2 to 6.0
 
 | 5.2 viewlet name | 5.2 viewlet manager | 6.0 viewlet name | 6.0 viewlet manager |
 | ---------------- | ------------------- | ---------------- | ------------------- |
-|| `plone.documentactions` | | |
-|||| `plone.belowcontentdescription` |
-| `plone.header` | `plone.portaltop` | | `plone.portaltop` |
-| `plone.abovecontenttitle.documentactions` | `plone.belowcontentbody` | `plone.documentactions` | `plone.belowcontent` |
-| `plone.abovecontenttitle.socialtags` | `plone.abovecontenttitle` | `plone.socialtags` | `plone.abovecontenttitle` |
-| `plone.belowcontentbody.relateditems` | `plone.belowcontentbody` | `plone.relateditems` | `plone.belowcontentbody` |
-| `plone.manage_portlets_fallback` | `plone.belowcontent` | | `plone.belowcontent` |
-| `plone.belowcontenttitle.documentbyline` | `plone.belowcontenttitle` | `plone.documentbyline` | `plone.belowcontenttitle` |
-| `plone.belowcontenttitle.keywords` | `plone.belowcontent` | `plone.keywords` | `plone.belowcontentbody` |
-| | `plone.belowcontentbody` | `plone.rights` | `plone.belowcontentbody` |
+|| `documentactions` | | |
+|||| `belowcontentdescription` |
+| `header` | `portaltop` | | `portaltop` |
+| `abovecontenttitle.documentactions` | `belowcontentbody` | `documentactions` | `belowcontent` |
+| `abovecontenttitle.socialtags` | `abovecontenttitle` | `socialtags` | `abovecontenttitle` |
+| `belowcontentbody.relateditems` | `belowcontentbody` | `relateditems` | `belowcontentbody` |
+| `manage_portlets_fallback` | `belowcontent` | | `belowcontent` |
+| `belowcontenttitle.documentbyline` | `belowcontenttitle` | `documentbyline` | `belowcontenttitle` |
+| `belowcontenttitle.keywords` | `belowcontent` | `keywords` | `belowcontentbody` |
+| | `belowcontentbody` | `rights` | `belowcontentbody` |
 ```
 
 One final change is that Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -625,7 +625,6 @@ Plone 6.0 removes such references from the viewlet names to avoid confusion.
 The names in the following table have had the namespace `plone.` removed from them for display purposes only.
 In your code, you should use the object's `plone.` namespace as a prefix.
 This table shows the same information, but in tabular form.
-You can toggle navigation to make more of the table visible.
 
 ```{table} Viewlet changes from 5.2 to 6.0
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-60.md
@@ -610,10 +610,6 @@ This is because some viewlet names contained the name of a viewlet manager.
 This didn't always match the name of their actual viewlet manager, especially after moving them.
 Plone 6.0 removes such references from the viewlet names to avoid confusion.
 
--   Plone 6.0 removes the `plone.documentactions` (`IDocumentActions`) viewlet manager.
-    In Plone 5.2 it was already empty.
--   Plone 6.0 adds the `plone.belowcontentdescription` (`IBelowContentDescription`) viewlet manager.
-    By default this has no viewlets.
 -   Plone 6.0 removes the `plone.header` viewlet from `plone.portaltop` manager, making it empty.
 -   Plone 6.0 renames the `plone.abovecontenttitle.documentactions` viewlet to `plone.documentactions`, and moves it from manager `plone.belowcontentbody` to `plone.belowcontent`.
 -   Plone 6.0 renames the `plone.abovecontenttitle.socialtags` viewlet to `plone.socialtags`.
@@ -635,8 +631,6 @@ You can toggle navigation to make more of the table visible.
 
 | 5.2 viewlet name | 5.2 viewlet manager | 6.0 viewlet name | 6.0 viewlet manager |
 | ---------------- | ------------------- | ---------------- | ------------------- |
-|| `documentactions` | | |
-|||| `belowcontentdescription` |
 | `header` | `portaltop` | | `portaltop` |
 | `abovecontenttitle.documentactions` | `belowcontentbody` | `documentactions` | `belowcontent` |
 | `abovecontenttitle.socialtags` | `abovecontenttitle` | `socialtags` | `abovecontenttitle` |
@@ -646,6 +640,13 @@ You can toggle navigation to make more of the table visible.
 | `belowcontenttitle.keywords` | `belowcontent` | `keywords` | `belowcontentbody` |
 | | `belowcontentbody` | `rights` | `belowcontentbody` |
 ```
+
+Plone 6.0 makes changes to two viewlet managers:
+
+-   Plone 6.0 removes the `plone.documentactions` (`IDocumentActions`) viewlet manager.
+    In Plone 5.2 it was already empty.
+-   Plone 6.0 adds the `plone.belowcontentdescription` (`IBelowContentDescription`) viewlet manager.
+    By default this has no viewlets.
 
 One final change is that Plone 6.0 moves the `plone.footer` viewlet from `plone.app.layout/viewlets` to `plone.app.portlets`.
 The viewlet remains in manager `plone.portalfooter`.


### PR DESCRIPTION
## Issue number

- Fixes https://github.com/plone/Products.CMFPlone/issues/3911

## Description

This adds a section to the upgrade guide from Plone 5.2 to 6.0 for the backend.  It documents the changes and moves of viewlets.

I have added a table, but really it is too wide: it partially falls behind the table of contents.  I wonder if something can be done about that.

