### PR TITLE
Fix syntax of netlify.toml headers.values

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
   PYTHON_VERSION = "3.8"
 [[headers]]
   for = "/*"
-  [[headers.values]]
+  [headers.values]
     X-Robots-Tag = "none"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Sphinx<5,>=3  # sphinx-book-theme 0.3.3 has requirement sphinx<5,>=3
 graphviz
 lesscpy
 linkify-it-py
-myst-parser>=2.0.0,<3.0.0  # Remove pin when upgrading to latest sphinx-book-theme
+myst-parser
 pydata-sphinx-theme==0.8.1  # Build fails in 0.9.0. See https://github.com/plone/documentation/issues/1297
 sphinx-autobuild
 sphinx-book-theme==0.3.3  # Temporary pin until we can sort out HTML refactoring.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Sphinx<5,>=3  # sphinx-book-theme 0.3.3 has requirement sphinx<5,>=3
 graphviz
 lesscpy
 linkify-it-py
-myst-parser
+myst-parser>=2.0.0,<3.0.0  # Remove pin when upgrading to latest sphinx-book-theme
 pydata-sphinx-theme==0.8.1  # Build fails in 0.9.0. See https://github.com/plone/documentation/issues/1297
 sphinx-autobuild
 sphinx-book-theme==0.3.3  # Temporary pin until we can sort out HTML refactoring.


### PR DESCRIPTION
Fix syntax of `netlify.toml` `headers.values` to prevent search engine indexing of Netlify preview builds