### PR TITLE
Opsworks was EOL on May 26, 2024

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -94,9 +94,6 @@ S3
 TTW
     Through-The-Web allows editing or customizing a Plone site through a web browser.
 
-Amazon Opsworks
-    [AWS OpsWorks](https://aws.amazon.com/opsworks/) is a configuration management service that uses Chef, an automation platform that treats server configurations as code.
-
 Ansible
     [Ansible](https://www.ansible.com/) is an open source automation platform.
     Ansible can help you with configuration management, application deployment, task automation.


### PR DESCRIPTION
See https://aws.amazon.com/blogs/mt/seamlessly-off-board-from-aws-opsworks-stacks-by-detaching-resources/


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1685.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->