### PR TITLE
Add documentation on how to use Weblate for translations

### DIFF
--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -77,7 +77,7 @@ The process of translating the Volto frontend is the following.
 
 4. Commit your changes, and create a pull request.
 
-(contributing-plone-core-translations-using-weblate)=
+(contributing-weblate-for-translations)=
 
 ## Weblate for translations
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -91,6 +91,10 @@ This means that the translator can go to the [Plone project and Weblate](https:/
 
 You will need to create an account there and then your translations will be automatically contributed back to Plone's GitHub repository.
 
+```{note}
+At this moment Volto translations can't be contributed using Weblate. We are working on this issue and we hope to have it fixed as soon as possible.
+```
+
 
 (contributing-plone-core-translations-support-label)=
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -79,7 +79,7 @@ The process of translating the Volto frontend is the following.
 
 (contributing-plone-core-translations-using-weblate)=
 
-## Using Weblate to translate Plone
+## Weblate for translations
 
 [Weblate](https://weblate.org/) is an Open Source project to help software developers translate their projects.
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -81,7 +81,7 @@ The process of translating the Volto frontend is the following.
 
 ## Weblate for translations
 
-[Weblate](https://weblate.org/) is an Open Source project to help software developers translate their projects.
+[Weblate](https://weblate.org/) is an open source project to help software developers translate their projects.
 
 It lets the translator to work in a web based interface, without the need of installing any third-party software or without the need to use git or GitHub.
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -83,7 +83,7 @@ The process of translating the Volto frontend is the following.
 
 [Weblate](https://weblate.org/) is an open source project to help software developers translate their projects.
 
-It lets the translator to work in a web based interface, without the need of installing any third-party software or without the need to use git or GitHub.
+Translators can work in a web interface, and not have to install third-party software or use git or GitHub.
 
 Plone Foundation has obtained a so called `libre` account for Plone, meaning we get the hosting with many other Open Source Projects at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to Open Source projects.
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -85,7 +85,8 @@ The process of translating the Volto frontend is the following.
 
 Translators can work in a web interface, and not have to install third-party software or use git or GitHub.
 
-Plone Foundation has obtained a so called `libre` account for Plone, meaning we get the hosting with many other Open Source Projects at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to Open Source projects.
+The Plone Foundation has obtained a "gratis Libre plan" account for Plone.
+Plone gets free hosting at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to open source projects.
 
 This means that the translator can go to the [Plone project and Weblate](https://hosted.weblate.org/projects/plone/) and start translating there.
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -81,7 +81,7 @@ The process of translating the Volto frontend is the following.
 
 ## Weblate for translations
 
-[Weblate](https://weblate.org/) is an open source project to help software developers translate their projects.
+[Weblate](https://weblate.org/en/) is an open source project to help software developers translate their projects.
 Translators can work in a web interface, and not have to install third-party software or use git or GitHub.
 The Plone Foundation has obtained a "gratis Libre plan" account for Plone.
 Plone gets free hosting at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to open source projects.

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -88,7 +88,7 @@ Translators can work in a web interface, and not have to install third-party sof
 The Plone Foundation has obtained a "gratis Libre plan" account for Plone.
 Plone gets free hosting at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to open source projects.
 
-This means that the translator can go to the [Plone project and Weblate](https://hosted.weblate.org/projects/plone/) and start translating there.
+Translators can go to the [Plone project in Weblate](https://hosted.weblate.org/projects/plone/) to write translations.
 
 You will need to create an account there and then your translations will be automatically contributed back to Plone's GitHub repository.
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -94,7 +94,8 @@ Translators will need to create an account there.
 Then your translations will be automatically contributed back to Plone's GitHub repository.
 
 ```{note}
-At this moment Volto translations can't be contributed using Weblate. We are working on this issue and we hope to have it fixed as soon as possible.
+At this moment Volto translations can't be contributed using Weblate.
+The Volto Team are working on this issue, and hope to fix it as soon as possible.
 ```
 
 

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -90,7 +90,8 @@ Plone gets free hosting at the [Hosted](https://hosted.weblate.org/) platform th
 
 Translators can go to the [Plone project in Weblate](https://hosted.weblate.org/projects/plone/) to write translations.
 
-You will need to create an account there and then your translations will be automatically contributed back to Plone's GitHub repository.
+Translators will need to create an account there.
+Then your translations will be automatically contributed back to Plone's GitHub repository.
 
 ```{note}
 At this moment Volto translations can't be contributed using Weblate. We are working on this issue and we hope to have it fixed as soon as possible.

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -82,21 +82,35 @@ The process of translating the Volto frontend is the following.
 ## Weblate for translations
 
 [Weblate](https://weblate.org/) is an open source project to help software developers translate their projects.
-
 Translators can work in a web interface, and not have to install third-party software or use git or GitHub.
-
 The Plone Foundation has obtained a "gratis Libre plan" account for Plone.
 Plone gets free hosting at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to open source projects.
 
-Translators can go to the [Plone project in Weblate](https://hosted.weblate.org/projects/plone/) to write translations.
 
-Translators will need to create an account there.
-Then your translations will be automatically contributed back to Plone's GitHub repository.
+### Weblate workflow
+
+Translators will need to create an account on Weblate with an email and password.
+Authentication with GitHub and other third-party accounts might not work.
+
+Translators can go to the [Plone project in Weblate](https://hosted.weblate.org/projects/plone/).
+
+You will see several components listed.
+The `volto` component is for the package `volto`, whose repository is at https://github.com/plone/volto.
 
 ```{note}
 At this moment Volto translations can't be contributed using Weblate.
 The Volto Team are working on this issue, and hope to fix it as soon as possible.
 ```
+
+All other components are for the package `plone.app.locales`, whose repository is at https://github.com/collective/plone.app.locales.
+
+See the Weblate documentation, [Translating using Weblate](https://docs.weblate.org/en/latest/user/translating.html), for how to use it to write translations.
+
+When you save a translation, then it is committed on a branch used only for translations in the respective GitHub repository.
+
+[Compare recent commits to the branch `translations-plone` on the package `plone.app.locales`](https://github.com/collective/plone.app.locales/compare/master...translations-plone).
+
+Maintainers will periodically create a pull request from the changes, and merge it.
 
 
 (contributing-plone-core-translations-support-label)=

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -77,6 +77,20 @@ The process of translating the Volto frontend is the following.
 
 4. Commit your changes, and create a pull request.
 
+(contributing-plone-core-translations-using-weblate)=
+
+## Using Weblate to translate Plone
+
+[Weblate](https://weblate.org/) is an Open Source project to help software developers translate their projects.
+
+It lets the translator to work in a web based interface, without the need of installing any third-party software or without the need to use git or GitHub.
+
+Plone Foundation has obtained a so called `libre` account for Plone, meaning we get the hosting with many other Open Source Projects at the [Hosted](https://hosted.weblate.org/) platform that Weblate offers to Open Source projects.
+
+This means that the translator can go to the [Plone project and Weblate](https://hosted.weblate.org/projects/plone/) and start translating there.
+
+You will need to create an account there and then your translations will be automatically contributed back to Plone's GitHub repository.
+
 
 (contributing-plone-core-translations-support-label)=
 


### PR DESCRIPTION
Now we can use [Weblate](https://hosted.weblate.org/projects/plone/) to translate Plone, so I have added a section in the How to contribute page explaining it.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1687.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->