### PR TITLE
Plone 6.0.12

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -350,7 +350,7 @@ def source_replace(app, docname, source):
 # Dict of replacements.
 source_replacements = {
     "{PLONE_BACKEND_MINOR_VERSION}": "6.0",
-    "{PLONE_BACKEND_PATCH_VERSION}": "6.0.11.1",
+    "{PLONE_BACKEND_PATCH_VERSION}": "6.0.12",
     "{NVM_VERSION}": "0.39.5",
     "{SUPPORTED_PYTHON_VERSIONS}": "3.8, 3.9, 3.10, 3.11, or 3.12",
 }


### PR DESCRIPTION
Released today.  Wait until a new `plone-backend` Docker image has been released.
See https://github.com/plone/plone-backend/pull/148

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1688.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->