### PR TITLE
Fix redirect to Docker documentation

### DIFF
--- a/docs/install/containers/images/backend.md
+++ b/docs/install/containers/images/backend.md
@@ -31,7 +31,7 @@ There are several ways to store data used by applications that run in Docker con
 
 We encourage users of the `Plone` images to familiarize themselves with the options available.
 
-[The Docker documentation](https://docs.docker.com/guides/docker-concepts/running-containers/persisting-container-data) is a good starting point for understanding the different storage options and variations.
+[The Docker documentation](https://docs.docker.com/get-started/docker-concepts/running-containers/persisting-container-data/) is a good starting point for understanding the different storage options and variations.
 
 
 ## Configuration Variables

--- a/docs/install/containers/index.md
+++ b/docs/install/containers/index.md
@@ -55,7 +55,7 @@ See its {ref}`install-packages-hardware-requirements-label`.
 
 ### Install Docker
 
-Install [Docker Desktop](https://docs.docker.com/get-docker/) for your operating system.
+Install [Docker Desktop](https://docs.docker.com/get-started/get-docker/) for your operating system.
 
 Docker Desktop includes all Docker tools.
 {term}`Docker Compose` is one of the Docker tools that will be used in much of this documentation.


### PR DESCRIPTION
Wait until https://github.com/plone/volto/pull/6262 is merged and I update its submodule tip accordingly.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1693.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->