### PR TITLE
Update translation command to make i18n.

### DIFF
--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -75,7 +75,7 @@ The process of translating the Volto frontend is the following.
     -  To update a translation, translate your language's `po` file found at `locales/{language_code}/LC_MESSAGES/volto.po`.
     -  To create a new translation, create a new directory at `locales/{language_code}/LC_MESSAGES/`, copy the file `locales/volto.pot` to `locales/{language_code}/LC_MESSAGES/volto.po` (note to drop the trailing `t`), and start translating.
 
-4. Run `yarn i18n` to convert your `po` files into `json`.
+4. Run `make i18n` to convert your `po` files into `json`.
    Volto loads these `json` files to provide translated text strings in the interface.
 
 5. Commit your changes, and create a pull request.

--- a/docs/i18n-l10n/resync-translations.md
+++ b/docs/i18n-l10n/resync-translations.md
@@ -103,10 +103,10 @@ When the release manager requests to create a new `plone.app.locales` release, t
 ## Resync translations in Volto
 
 In Volto, the GitHub test setup warns a developer when their new contributions require regenerating the translation file.
-This is done by running a yarn script as follows:
+This is done by running a make command as follows:
 
 ```shell
-yarn i18n
+make i18n
 ```
 
 This will update the PO files and will leave them ready to be translated by translators.
@@ -116,9 +116,9 @@ This will update the PO files and will leave them ready to be translated by tran
 
 ## Create a release of Volto with the new translations
 
-The Volto release process requires running the same yarn script as in the previous step.
+The Volto release process requires running the same make command as in the previous step.
 It will convert the translations in PO files to the JSON files that Volto uses to render the user interface.
 
 ```shell
-yarn i18n
+make i18n
 ```


### PR DESCRIPTION
References plone/volto/pull/6274

Updated translation command at https://6.docs.plone.org/i18n-l10n/contributing-translations.html#translate-volto  to use make i18n.