### PR TITLE
explain how to avoid errors when overriding translations

### DIFF
--- a/docs/i18n-l10n/translating-text-strings.md
+++ b/docs/i18n-l10n/translating-text-strings.md
@@ -437,6 +437,31 @@ environment-vars =
 zcml = my.package
 ```
 
+When doing so, you may need to add the following zcml stanza in your package's `configure.zcml` file:
+
+```xml
+
+<include package="Products.CMFPlone" />
+
+```
+
+This **must** go *after* the `registerTranslations` stanza, before any other registration you may have in your package.
+
+It should look like this:
+
+```xml
+<configure xmlns:i18n="http://namespaces.zope.org/i18n"
+           i18n_domain="my.package">
+    <i18n:registerTranslations directory="locales" />
+    
+    <include package="Products.CMFPlone" />
+
+    <!-- any other registration -->
+
+</configure>
+```
+
+
 See the *Overriding Translations* section of Maurits van Rees's [blog entry on Plone i18n](https://maurits.vanrees.org/weblog/archive/2010/10/i18n-plone-4#overriding-translations).
 
 

--- a/docs/i18n-l10n/translating-text-strings.md
+++ b/docs/i18n-l10n/translating-text-strings.md
@@ -437,17 +437,15 @@ environment-vars =
 zcml = my.package
 ```
 
-When doing so, you may need to add the following zcml stanza in your package's `configure.zcml` file:
+When doing so, you may need to add the following ZCML stanza in your package's {file}`configure.zcml` file:
 
 ```xml
-
 <include package="Products.CMFPlone" />
-
 ```
 
-This **must** go *after* the `registerTranslations` stanza, before any other registration you may have in your package.
+This **must** go *after* the `registerTranslations` stanza, and before any other registration you might have in your package.
 
-It should look like this:
+The registration should look like the following example.
 
 ```xml
 <configure xmlns:i18n="http://namespaces.zope.org/i18n"


### PR DESCRIPTION
In a project we needed to override some translations and after doing what is documented and restarting the instance we got some configuration errors saying that some component was not available.

We tracked it down to some ZCMLs not being loaded when our package's ZCML was loaded, so we fixed it explicetly include Products.CMFPlone's zcml in our package, and that's what we document here.

@libargutxi 

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1698.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->