### PR TITLE
Remove obsolete and dead link for collective packages still needed to migrate to Python 3

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-python3.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-python3.md
@@ -14,9 +14,6 @@ myst:
 
 This chapter provides instructions and tips for porting Plone projects to Python 3.
 
-```{seealso}
-If you want to upgrade add-ons to Python 3, the list of all Plone packages that still need to be ported can be found on the GitHub project board [Python 3 porting state for Plone add-ons](https://github.com/orgs/collective/projects/1).
-```
 
 ## Principles
 


### PR DESCRIPTION


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1708.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->