### PR TITLE
Disable VSCode's format-on-save feature for markdown

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "[markdown]": {
+    "editor.formatOnSave": false
+  }
+}


### PR DESCRIPTION
This should help avoid contributors accidentally reformatting (the default formatter makes changes we don't want, like converting to the wrong quotes)

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1713.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->