### PR TITLE
Add html_meta stuff for annotations.md

### DIFF
--- a/docs/backend/annotations.md
+++ b/docs/backend/annotations.md
@@ -1,10 +1,10 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "Annotations store arbitrary values on Python objects—such as a Plone site or HTTP request—for storage and caching purposes."
+    "property=og:description": "Annotations store arbitrary values on Python objects—such as a Plone site or HTTP request—for storage and caching purposes."
+    "property=og:title": "Annotations"
+    "keywords": "Annotations, plone.memoize, cache, portal, content object"
 ---
 
 (backend-annotations-label)=


### PR DESCRIPTION
I'm tired of these stupid warnings.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1718.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->