### PR TITLE
Move Classic UI immediately after Volto UI

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -523,7 +523,7 @@ manual `.po` entries
     Entries which cannot be detected by an automatic code scan.
 
 react-intl
-    A library that is part of [Format.JS](https://formatjs.io/docs/getting-started/installation) which helps developers set up their applications for internationalization.
+    A library that is part of [Format.JS](https://formatjs.github.io/) which helps developers set up their applications for internationalization.
 
 WSGI
     The Web Server Gateway Interface (WSGI, pronounced _WIZ-ghee_) is a simple calling convention for web servers to forward requests to web applications or frameworks written in the Python programming language.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,9 @@ manage/index
 upgrade/index
 deployment/index
 volto/index
+classic-ui/index
 plone.restapi/docs/source/index
 backend/index
-classic-ui/index
 i18n-l10n/index
 conceptual-guides/index
 contributing/index


### PR DESCRIPTION
Closes #1740. Wait for https://github.com/plone/volto/pull/6438 to be merged first.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1741.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->