### PR TITLE
Ignore https://opensource.org/ on linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ linkcheck_ignore = [
     r"https://github.com/orgs/plone/teams/",  # requires auth
     r"https://github.com/plone/documentation/issues/new/choose",  # requires auth
     r"https://github.com/plone/volto/issues/new/choose",  # requires auth
+    r"https://opensource.org/",  # requires auth
     # Ignore github.com pages with anchors
     r"https://github.com/.*#.*",
     # Ignore other specific anchors


### PR DESCRIPTION


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1745.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->