### PR TITLE
Update glossary to align with Volto

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -706,12 +706,6 @@ Windows Subsystem for Linux
 pnpm
     [pnpm](https://pnpm.io/) is a fast, disk space efficient package manager.
 
-Guillotina
-    [Guillotina](https://guillotina.io/) is a full-stack data framework built on [AsyncIO](https://docs.python.org/3/library/asyncio.html).
-
-Nick
-    [Nick](https://nickcms.org/) is a headless content management system {term}`CMS` built with {term}`Node.js`.
-
 predicate
 predicates
     In programming, a predicate is a test which returns `true` or `false`.


### PR DESCRIPTION
See https://github.com/plone/volto/pull/6433

Merge only after the Volto PR is merged.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1747.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->