### PR TITLE
Improve install docs

### DIFF
--- a/docs/admin-guide/index.md
+++ b/docs/admin-guide/index.md
@@ -11,7 +11,7 @@ myst:
 
 # Admin guide
 
-In this part of the documentation, you can find how to install, operate, configure, and deploy Plone.
+In this part of the documentation, you can find how to install, operate and configure Plone.
 
 
 ```{toctree}

--- a/docs/admin-guide/index.md
+++ b/docs/admin-guide/index.md
@@ -11,7 +11,7 @@ myst:
 
 # Admin guide
 
-In this part of the documentation, you can find how to install, operate and configure Plone.
+In this part of the documentation, you can find how to install, operate, and configure Plone.
 
 
 ```{toctree}

--- a/docs/admin-guide/install-buildout.md
+++ b/docs/admin-guide/install-buildout.md
@@ -25,7 +25,7 @@ For other installation options, see {ref}`get-started-install-label`.
 ## Prerequisites for installation
 
 -   For Plone 6.0, Python {SUPPORTED_PYTHON_VERSIONS_PLONE60}
-% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest". 
+% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest".
 % -   For Plone 6.1, Python {SUPPORTED_PYTHON_VERSIONS_PLONE61}
 
 
@@ -47,14 +47,16 @@ cd <my_projects>/plone
 Create a Python virtual environment.
 
 ```shell
-python3 -m venv .
+python3 -m venv venv
 ```
 
 Install the minimal Python packages needed in order to run Buildout.
 
 ```shell
-bin/pip install -r https://dist.plone.org/release/6-latest/requirements.txt
+venv/bin/pip install -r https://dist.plone.org/release/6-latest/requirements.txt
 ```
+
+
 
 Create a {file}`buildout.cfg` file in your directory with the following contents.
 
@@ -75,6 +77,12 @@ eggs =
     Plone
 ```
 
+Install Buildout script in bin directory.
+
+```shell
+venv/bin/buildout bootstrap
+```
+
 Run Buildout.
 
 ```shell
@@ -83,6 +91,7 @@ bin/buildout
 
 This may take a few minutes.
 
+When ever the buildout configuration has changed, re-run ./bin/buildout
 
 ## Start Plone in foreground mode
 

--- a/docs/admin-guide/install-buildout.md
+++ b/docs/admin-guide/install-buildout.md
@@ -77,7 +77,7 @@ eggs =
     Plone
 ```
 
-Install Buildout script in bin directory.
+Use Buildout's [`bootstrap` command](https://www.buildout.org/en/latest/topics/bootstrapping.html) to install a local `buildout` script in the {file}`bin` directory.
 
 ```shell
 venv/bin/buildout bootstrap
@@ -91,7 +91,7 @@ bin/buildout
 
 This may take a few minutes.
 
-When ever the buildout configuration has changed, re-run ./bin/buildout
+Whenever you change the Buildout configuration, run `./bin/buildout` again.
 
 ## Start Plone in foreground mode
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -53,7 +53,7 @@ python3 -m venv venv
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
-./venv/bin/pip install -c https://dist.plone.org/release/6.0-latest/constraints.txt Plone pipx
+venv/bin/pip install -c https://dist.plone.org/release/6.0-latest/constraints.txt Plone pipx
 ```
 
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -25,7 +25,7 @@ For other installation options, see {ref}`get-started-install-label`.
 ## Prerequisites for installation
 
 -   For Plone 6.0, Python {SUPPORTED_PYTHON_VERSIONS_PLONE60}
-% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest". 
+% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest".
 % -   For Plone 6.1, Python {SUPPORTED_PYTHON_VERSIONS_PLONE61}
 
 
@@ -47,13 +47,13 @@ cd <my_projects>/plone
 Create a Python virtual environment.
 
 ```shell
-python3 -m venv .
+python3 -m venv venv
 ```
 
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
-bin/pip install -c https://dist.plone.org/release/6.0-latest/constraints.txt Plone pipx
+./venv/bin/pip install -c https://dist.plone.org/release/6.0-latest/constraints.txt Plone pipx
 ```
 
 

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -18,7 +18,7 @@ There are different commands to run Plone, depending on which method you used to
 ## Run Plone in foreground mode
 
 Running Plone in foreground mode will show output in the terminal.
-This is recommended while developing a Plone site.
+This is recommended while developing a Plone site. The command to be used, depends on the used install method.
 
 Cookieplone:
 :   ```shell

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -18,7 +18,8 @@ There are different commands to run Plone, depending on which method you used to
 ## Run Plone in foreground mode
 
 Running Plone in foreground mode will show output in the terminal.
-This is recommended while developing a Plone site. The command to be used depends on the install method you used.
+This is recommended while developing a Plone site.
+The command you use depends on the installation method you used.
 
 Cookieplone:
 :   ```shell

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -18,7 +18,7 @@ There are different commands to run Plone, depending on which method you used to
 ## Run Plone in foreground mode
 
 Running Plone in foreground mode will show output in the terminal.
-This is recommended while developing a Plone site. The command to be used, depends on the used install method.
+This is recommended while developing a Plone site. The command to be used depends on the install method you used.
 
 Cookieplone:
 :   ```shell


### PR DESCRIPTION
This corrects the creation of Python venv. We shoud never mix the venv with other configuration like the buildout configuration or others. This can lead to losing data or configuration when updating the venv later.

so instead of 

`python3 -m venv .`

we should  use 

`python3 -m venv venv`

or similar to create a venv.
Then either activate the venv or use it like this

`./venv/bin/pip install Plone`

The buildout bootstrap command is useful to avoid the need to always prefix the buildout run with the venv path later.
It will create the `bin/buildout` script and only need to run once.