### PR TITLE
Add comparison between Buildout and pip installation tools for Classi…

### DIFF
--- a/docs/conceptual-guides/compare-buildout-pip.md
+++ b/docs/conceptual-guides/compare-buildout-pip.md
@@ -1,0 +1,38 @@
+---
+myst:
+  html_meta:
+    "description": "Compare Plone Classic UI's installation tools, Buildout and pip"
+    "property=og:description": "Compare Plone Classic UI's installation tools, Buildout and pip"
+    "property=og:title": "Compare Buildout and pip"
+    "keywords": "Plone 6, Conceptual guides, Classic UI, Buildout, pip, install"
+---
+
+# Compare Buildout and pip
+
+This guide explains the differences between two tools, {term}`Buildout` and {term}`pip`, to install Plone and its Classic UI user interface, helping to inform your choice when developing your new project in Plone.
+
+The choice of installation tool has implications for admins and developers.
+
+````{grid} 1 1 1 2
+:gutter: 1
+:margin: 0
+:padding: 0
+
+```{grid-item-card} Buildout
+-   You can create recipes to automate development and production installations.
+-   Maintained and used primarily by the small Plone community.
+-   May have problems resolving dependencies when a new pip or setuptools version is released.
+-   Source checkouts managed through {term}`mr.developer`.
+```
+
+```{grid-item-card} pip
+-   Installs or uninstalls packages only.
+-   Maintained and used by the large Python community.
+-   Changes in dependency resolution are well-documented.
+-   Source checkouts managed through {term}`mxdev`.
+```
+````
+
+```{seealso}
+[Proposal: Use pip constraints as canonical version location #3670](https://github.com/plone/Products.CMFPlone/issues/3670)
+```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -296,6 +296,9 @@ TC39
     They established a [process](https://tc39.es/process-document/) where the proposals are discussed, developed, and eventually approved (or dropped).
     The process has five Stages (0 to 4) where reaching the Stage 4 means the proposal is finished, and it becomes part of the JavaScript specification.
 
+`mr.developer`
+    [`mr.developer`](https://pypi.org/project/mr.developer/) is a {term}`Buildout` extension that makes it easy to work with buildouts containing lots of packages, where you only want to develop a few of them.
+
 `mrs-developer`
     Also called "missdev", a tool similar to buildout's `mr.developer`.
     It automatically downloads and keeps up to date copies of software and add-ons under development based on definitions stored in `mrs.developer.json`.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -41,6 +41,8 @@ https://demo.plone.org/
 First, choose a Plone user interface, or frontend.
 You can read {doc}`/conceptual-guides/choose-user-interface` to help inform your choice between Volto and Classic UI.
 
+If you choose Classic UI, then you can read {doc}`/conceptual-guides/compare-buildout-pip` to help inform your choice between Buildout and pip for an installation method.
+
 Then choose one of the following installation methods.
 If you are following a [Plone training](https://training.plone.org/), it should specify which option to choose.
 


### PR DESCRIPTION
…c UI

This PR fills a gap with a conceptual guide to inform users whether to choose Buildout or pip when installing Plone with Classic UI.

This is by no means a comprehensive comparison, but only what I was able to collect from various comments and notes. Feedback greatly appreciated.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1766.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->