### PR TITLE
Fix reference to Plone 5 docs

### DIFF
--- a/docs/backend/search.md
+++ b/docs/backend/search.md
@@ -11,7 +11,7 @@ myst:
 
 # Search
 
-To index and search content in Plone, see the Plone 5 documentation {doc}`/develop/plone/searching_and_indexing/index`.
+To index and search content in Plone, see the Plone 5 documentation {doc}`plone5:develop/plone/searching_and_indexing/index`.
 
 Alternatively, you can integrate any open source search engine with your Plone site.
 


### PR DESCRIPTION


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1767.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->