### PR TITLE
Support sphinxcontrib-mermaid 1.0.0 by removing outdated pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ sphinxcontrib.httpdomain
 sphinxcontrib.httpexample
 sphinxcontrib-video
 sphinxext-opengraph
-sphinxcontrib.mermaid==0.9.2
+sphinxcontrib.mermaid
 vale


### PR DESCRIPTION
@jensens FYI. I just checked, and noticed that 1.0.0 had been released of sphinxcontrib-mermaid.

See also https://github.com/plone/documentation/issues/1683

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1777.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->