### PR TITLE
Fix the syntax for command line options to `suppress_warnings`

### DIFF
--- a/docs/contributing/documentation/authors.md
+++ b/docs/contributing/documentation/authors.md
@@ -75,7 +75,7 @@ make SPHINXOPTS="OPTION VALUE" BUILDER
 The following example shows how to clean then build a live HTML preview of the documentation while suppressing syntax highlighting failures.
 
 ```shell
-make SPHINXOPTS="-D suppress_warnings=['misc.highlighting_failure']" clean livehtml
+make SPHINXOPTS="-D suppress_warnings='misc.highlighting_failure'" clean livehtml
 ```
 
 


### PR DESCRIPTION
Command line options must be a string, not a list.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1799.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->