### PR TITLE
Fix linkcheck to 2023 Trainings

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/p4x-to-p5x-upgrade.md
+++ b/docs/backend/upgrading/version-specific-migration/p4x-to-p5x-upgrade.md
@@ -448,7 +448,7 @@ The value you use for this CSS rule should identify one of the fontello icons in
 
 It is not possible at this time to set an icon for your add-on package control panels without including CSS in your package.
 
-For documentation on how to use it in your own add-ons see {doc}`training:mastering-plone-5/registry`.
+For documentation on how to use it in your own add-ons see {doc}`training-2023:mastering-plone-5/registry`.
 
 
 ### Properties

--- a/docs/classic-ui/viewlets.md
+++ b/docs/classic-ui/viewlets.md
@@ -209,7 +209,7 @@ The following Python code example, such as in a file {file}`viewlets.py`, extend
 ```{todo}
 The following Facebook like viewlet example is obsolete (note that links use `http`) and needs to be replaced with a modern one.
 The concept is valid, but the code will not actually work with Facebook.
-For a somewhat more recent example, see {doc}`training:mastering-plone-5/viewlets_1` in the Master Plone 5 training.
+For a somewhat more recent example, see {doc}`training-2023:mastering-plone-5/viewlets_1` in the Master Plone 5 training.
 ```
 
 ```python

--- a/docs/classic-ui/views.md
+++ b/docs/classic-ui/views.md
@@ -663,9 +663,9 @@ This way you will also have a test for the generated view.
 
 The Mastering Plone 5 Training has several chapters on views.
 
--   {doc}`training:mastering-plone-5/views_1`
--   {doc}`training:mastering-plone-5/views_2`
--   {doc}`training:mastering-plone-5/views_3`
+-   {doc}`training-2023:mastering-plone-5/views_1`
+-   {doc}`training-2023:mastering-plone-5/views_2`
+-   {doc}`training-2023:mastering-plone-5/views_3`
 
 
 (classic-ui-anatomy-of-a-view-label)=

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -343,6 +343,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "training": ("https://training.plone.org/", None),
     "training-2022": ("https://2022.training.plone.org/", None),
+    "training-2023": ("https://2023.training.plone.org/", None),
 }
 
 


### PR DESCRIPTION
This fixes links to the 2023 version of Mastering Plone 5 Training, which has now been archived.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1800.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->