### PR TITLE
Add cross-reference to Training in the primary navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,4 +52,12 @@ contributing/index
 glossary
 ```
 
+```{toctree}
+:caption: Tutorials
+:maxdepth: 1
+:hidden: true
+
+training/index
+```
+
 {ref}`genindex`

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,0 +1,12 @@
+---
+myst:
+  html_meta:
+    "description": "Plone Training"
+    "property=og:description": "Plone Training"
+    "property=og:title": "Plone Training"
+    "keywords": "Plone, Training"
+---
+
+# Plone Training
+
+See {doc}`training:index`.


### PR DESCRIPTION
See https://github.com/plone/training/pull/894

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1801.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->