### PR TITLE
fix: pillow installation for linux

### DIFF
--- a/docs/_inc/_install-pillow.md
+++ b/docs/_inc/_install-pillow.md
@@ -1,5 +1,5 @@
 ``````{note}
-After generating a project, then running `make install`, if you see an error message `ERROR: Failed building wheel for Pillow`, then you need to install Pillow's dependencies.
+After generating a project, then running `make install`, if you see an error message `ERROR: Failed building wheel for Pillow` or `The headers or library files could not be found for jpeg, a required dependency when compiling Pillow from source.`, then you need to install Pillow's dependencies.
 
 `````{tab-set}
 

--- a/docs/_inc/_install-pillow.md
+++ b/docs/_inc/_install-pillow.md
@@ -11,7 +11,7 @@ brew install zlib libjpeg
 
 ````{tab-item} Linux
 ```shell
-apt-get zlib libjpeg
+apt install zlib1g-dev libjpeg8-dev
 ```
 ````
 `````


### PR DESCRIPTION
## Issue number

- Fixes #1804

## Description
- It updates the installation command with `apt install zlib1g-dev libjpeg8-dev`
- Fixes the error: 
```
The headers or library files could not be found for jpeg,
a required dependency when compiling Pillow from source.
```

I, Pulkit, agree to have this contribution published under Creative Commons 4.0 International License (CC BY 4.0), with attribution to the Plone Foundation.