### PR TITLE
Plone 6.0.14 and 6.1.0b2 are out with Python 3.13 support.

### DIFF
--- a/docs/_inc/_install-python-plone60.md
+++ b/docs/_inc/_install-python-plone60.md
@@ -3,6 +3,14 @@ However, it is recommended to use a Python version manager, {term}`pyenv`, that 
 
 Plone 6.0 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE60}}.
 
+```{versionadded} Plone 6.0.14 
+Support for Python 3.13.
+```
+
+```{versionremoved} Plone 6.0.14
+Support for Python 3.8.
+```
+
 ```{warning}
 Do not create or activate a Python virtual environment at this time.
 The instructions below will create one.

--- a/docs/backend/upgrading/intro.md
+++ b/docs/backend/upgrading/intro.md
@@ -118,8 +118,8 @@ If you are at Plone 2.5 and want to upgrade to the latest Plone 6, you should ap
 
 -   First upgrade from Plone 2.5 to the latest Plone 3 version (3.3.6).
 -   Then upgrade from Plone 3 to the latest Plone 4 version (4.3.20).
--   Then upgrade from Plone 4 to the latest Plone 5 version.
--   Then upgrade from Plone 5 to the latest Plone 6 version.
+-   Then upgrade from Plone 4 to the latest Plone 5 version (5.2.15).
+-   Then upgrade from Plone 5 to the latest Plone 6 version ({PLONE_BACKEND_PATCH_VERSION}).
 
 
 (introduction-upgrade-strategies-export-import-migrations-label)=

--- a/docs/conceptual-guides/package-management.md
+++ b/docs/conceptual-guides/package-management.md
@@ -32,11 +32,11 @@ If you want to check out a Plone core package for development, or want to overri
 
 ```text
 # constraints.txt with unresolvable version conflict
--c https://dist.plone.org/release/{PLONE_BACKEND_PATCH_VERSION}/constraints.txt
-plone.api>=2.0.0a3
+-c https://dist.plone.org/release/6.0.9/constraints.txt
+plone.api>=2.1.0
 ```
 
-Unfortunately `pip` does not allow overriding constraints this way. 
+Unfortunately `pip` does not allow overriding constraints this way.
 {term}`mxdev` solves this issue.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -441,7 +441,7 @@ def source_replace(app, docname, source):
 # Dict of replacements.
 source_replacements = {
     "{PLONE_BACKEND_MINOR_VERSION}": "6.0",
-    "{PLONE_BACKEND_PATCH_VERSION}": "4",
+    "{PLONE_BACKEND_PATCH_VERSION}": "6.0.14",
 }
 
 # Finally, configure app attributes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -441,7 +441,6 @@ def source_replace(app, docname, source):
 # Dict of replacements.
 source_replacements = {
     "{PLONE_BACKEND_MINOR_VERSION}": "6.0",
-    "{PLONE_BACKEND_PATCH_VERSION}": "6.0.14",
 }
 
 # Finally, configure app attributes.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,8 +318,8 @@ myst_substitutions = {
     "postman_response": "![](../_static/img/postman_response.png)",
     "postman_retain_headers": "![](../_static/img/postman_retain_headers.png)",
     "fawrench": '<span class="fa fa-wrench" style="font-size: 1.6em;"></span>',
-    "SUPPORTED_PYTHON_VERSIONS_PLONE60": "3.8, 3.9, 3.10, 3.11, or 3.12",
-    "SUPPORTED_PYTHON_VERSIONS_PLONE61": "3.10, 3.11, or 3.12",
+    "SUPPORTED_PYTHON_VERSIONS_PLONE60": "3.9, 3.10, 3.11, 3.12, or 3.13",
+    "SUPPORTED_PYTHON_VERSIONS_PLONE61": "3.10, 3.11, 3.12, or 3.13",
 }
 
 
@@ -441,7 +441,7 @@ def source_replace(app, docname, source):
 # Dict of replacements.
 source_replacements = {
     "{PLONE_BACKEND_MINOR_VERSION}": "6.0",
-    "{PLONE_BACKEND_PATCH_VERSION}": "6.0.13",
+    "{PLONE_BACKEND_PATCH_VERSION}": "4",
 }
 
 # Finally, configure app attributes.


### PR DESCRIPTION
Marked as draft PR, because the `plone-backend` Docker images are not ready yet.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1823.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->