### PR TITLE
Update package dependencies for 6.1.

### DIFF
--- a/docs/conceptual-guides/package-dependencies.md
+++ b/docs/conceptual-guides/package-dependencies.md
@@ -246,17 +246,21 @@ Looking deeper into those packages, there are more subdivisions which fall into 
 
 -   Plone
 -   plone.api
+-   plone.app.caching
+-   plone.app.discussion
 -   plone.app.iterate
+-   plone.app.multilingual
 -   plone.app.upgrade
+-   plone.classicui
+-   plone.distribution
+-   plone.exportimport
 -   plone.restapi
 -   plone.volto
 -   Products.CMFPlacefulWorkflow
 
-
 ### Between `Products.CMFPlone` and `plone.base`
 
 -   collective.monkeypatcher
--   plone.app.caching
 -   plone.app.content
 -   plone.app.contentlisting
 -   plone.app.contentmenu
@@ -264,7 +268,6 @@ Looking deeper into those packages, there are more subdivisions which fall into 
 -   plone.app.contenttypes
 -   plone.app.customerize
 -   plone.app.dexterity
--   plone.app.discussion
 -   plone.app.event
 -   plone.app.i18n
 -   plone.app.intid
@@ -272,7 +275,6 @@ Looking deeper into those packages, there are more subdivisions which fall into 
 -   plone.app.linkintegrity
 -   plone.app.locales
 -   plone.app.lockingbehavior
--   plone.app.multilingual
 -   plone.app.portlets
 -   plone.app.querystring
 -   plone.app.redirector


### PR DESCRIPTION
This is for this page: https://6.docs.plone.org/conceptual-guides/package-dependencies.html

This page only tries to describe Plone 6.1, right?

I made the following changes:

* `plone.app.discussion` and `multilingual` have become core add-ons, so they live above `CMFPlone`.
* `plone.app.caching` has always lived above `CMFPlone`, it was filed wrongly.
* `plone.classicui` is new above `CMFPlone`, and it pulls in `plone.distribution` and `plone.exportimport`.


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1825.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->