### PR TITLE
Add terms to Glossary for block extension examples

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -871,4 +871,18 @@ variation
     Extending this example, a developer can add a boolean field to the block that toggles the display of the link.
     Thus an editor can select between `title + link` or just `title`.
 
+HOC
+Higher-Order Component
+    A higher-order component (HOC) is an advanced technique in React for reusing component logic.
+    HOCs are not part of the React API, per se.
+    They are a pattern that emerges from React's compositional nature.
+    Concretely, a higher-order component is a function that takes a component and returns a new component.
+    
+    ```{important}
+    Higher-order components are not commonly used in modern React code.
+    ```
+    ```{seealso}
+    https://legacy.reactjs.org/docs/higher-order-components.html
+    ```
+
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -863,9 +863,12 @@ schema enhancer
     This function receives an object with `formData`, which is the block data; `schema`, which is the original schema to modify; and the injected `intl`, which aids with internationalization.
 
 variation
-    A variation is a common development pattern that provides versions of a given block.
-    You can use a variation to enhance the default behavior of a block without shadowing its stock components.
-    These enhancements can either be at the settings level via schema enhancers or, if the code of your block allows it, use alternative renderers showing the enhanced fields, modifying the block behavior or its look and feel.
-    Editors can select a variation on demand.
+    A variation is a common development pattern that provides alternative views for the same data.
+    For example, a teaser block can present data as `title + link`, `title + description + link`, or `title + image + link`.
+        
+    An advanced variation can enhance the block by adding data fields to the block.
+    For example, a listing block variation can show news items with `title + link`.
+    Extending this example, a developer can add a boolean field to the block that toggles the display of the link.
+    Thus an editor can select between `title + link` or just `title`.
 
 ```

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -857,4 +857,15 @@ Vale
     [Vale](https://vale.sh/) is an open-source, command-line tool that helps maintain a consistent and on-brand voice in documentation.
     Plone Documentation uses it to check spelling, English grammar and syntax, and style guides.
 
+schema enhancer
+    A schema enhancer uses the `schemaEnhancer` function, which can modify the schema used by the `InlineForm` component.
+    Any registered extension plugin can provide a `schemaEnhancer` function.
+    This function receives an object with `formData`, which is the block data; `schema`, which is the original schema to modify; and the injected `intl`, which aids with internationalization.
+
+variation
+    A variation is a common development pattern that provides versions of a given block.
+    You can use a variation to enhance the default behavior of a block without shadowing its stock components.
+    These enhancements can either be at the settings level via schema enhancers or, if the code of your block allows it, use alternative renderers showing the enhanced fields, modifying the block behavior or its look and feel.
+    Editors can select a variation on demand.
+
 ```


### PR DESCRIPTION
This needs to be merged before https://github.com/plone/volto/pull/6560 so that that PR can pull in the Glossary terms.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1829.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->