### PR TITLE
Fix link to Portal Modelo

### DIFF
--- a/docs/conceptual-guides/distributions.md
+++ b/docs/conceptual-guides/distributions.md
@@ -54,7 +54,7 @@ Examples of third-party Plone distributions include:
 
 - [SENAITE](https://www.senaite.com)
 - [Quaive](https://quaive.com/)
-- [Portal Modelo](https://www12.senado.leg.br/interlegis)
+- [Portal Modelo](https://www12.senado.leg.br/interlegis/produtos/portal-modelo)
 - [Portal Padrão](https://identidade-digital-de-governo-plone.readthedocs.io/en/latest/)
 
 

--- a/docs/conceptual-guides/distributions.md
+++ b/docs/conceptual-guides/distributions.md
@@ -54,7 +54,7 @@ Examples of third-party Plone distributions include:
 
 - [SENAITE](https://www.senaite.com)
 - [Quaive](https://quaive.com/)
-- [Portal Modelo](https://www.interlegis.leg.br/produtos-servicos/portal-modelo/)
+- [Portal Modelo](https://www12.senado.leg.br/interlegis)
 - [Portal Padrão](https://identidade-digital-de-governo-plone.readthedocs.io/en/latest/)
 
 


### PR DESCRIPTION
https://www.interlegis.leg.br/produtos-servicos/portal-modelo/ redirects to https://www12.senado.leg.br/interlegis

I am not sure whether it is still called Portal Modelo. Help!

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1832.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->