### PR TITLE
Distribution: add example for hiding fields from the form.

### DIFF
--- a/docs/developer-guide/create-a-distribution.md
+++ b/docs/developer-guide/create-a-distribution.md
@@ -245,6 +245,30 @@ You may have noticed the entries for both `default_language` and `portal_timezon
 `plone.distribution` adds both definitions at runtime, providing a list of languages and timezones available on the installation.
 ````
 
+If you want to hide fields in the form, you can use the `uischema`.
+This is especially useful for fields that must be in the schema, but for which you always want the default value.
+The next lines hide three fields:
+
+```json
+{
+  "schema": {
+    ...
+  },
+  "uischema": {
+      "description": {
+          "ui:widget": "hidden"
+      },
+      "default_language": {
+          "ui:widget": "hidden"
+      },
+      "portal_timezone": {
+          "ui:widget": "hidden"
+      }
+  }
+}
+```
+
+
 ## Add a dependency on an add-on
 
 If you want to add a Plone backend add-on to your Plone distribution, then you must perform the following steps.

--- a/docs/developer-guide/create-a-distribution.md
+++ b/docs/developer-guide/create-a-distribution.md
@@ -255,15 +255,15 @@ The next lines hide three fields:
     "…": "…"
   },
   "uischema": {
-      "description": {
-          "ui:widget": "hidden"
-      },
-      "default_language": {
-          "ui:widget": "hidden"
-      },
-      "portal_timezone": {
-          "ui:widget": "hidden"
-      }
+    "description": {
+      "ui:widget": "hidden"
+    },
+    "default_language": {
+      "ui:widget": "hidden"
+    },
+    "portal_timezone": {
+      "ui:widget": "hidden"
+    }
   }
 }
 ```

--- a/docs/developer-guide/create-a-distribution.md
+++ b/docs/developer-guide/create-a-distribution.md
@@ -252,7 +252,7 @@ The next lines hide three fields:
 ```json
 {
   "schema": {
-    ...
+    "…": "…"
   },
   "uischema": {
       "description": {


### PR DESCRIPTION
I am making a distribution for a client.

* I don't want to show the description field because it should remain empty (at least that is how it is on their current Plone 4 site).
* I don't want to show the default_language field, because I am setting this (and four available languages) in the Generic Setup profile.
* Same for the portal_timezone: it is a site for Belgium, so I am setting Europe/Brussels in the Generic Setup profile, so this timezone is always set, even when a colleague in Portugal creates a site on his laptop.

Unfortunately currently these fields have to be in the schema, as documented, otherwise you get an error. So instead  I found out how to hide these fields.



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1833.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->