### PR TITLE
Fix: Manually add content from _install-python-plone61.md into setup-…

### DIFF
--- a/docs/contributing/documentation/setup-build.md
+++ b/docs/contributing/documentation/setup-build.md
@@ -31,8 +31,15 @@ Installation of Plone 6 Documentation includes prerequisites and the repository 
 
 ### Python
 
-```{include} /_inc/_install-python-plone61.md
+Installing Python is beyond the scope of this documentation.
+However, it is recommended to use a Python version manager, {term}`pyenv`, that allows you to install multiple versions of Python on your development environment without destroying your system's Python.
+
+```{warning}
+Do not create or activate a Python virtual environment at this time.
+The instructions below will create one.
 ```
+
+Plone 6.1 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}.
 
 (setup-build-installation-gnu-make-label)=
 


### PR DESCRIPTION
…build.md

Removed the problematic `{include}` directive in setup-build.md due to issues with GitHub preview. Manually copied the content from the file docs/_inc/_install-python-plone61.md into setup-build.md to ensure proper display and functionality. The path in the original `{include}` directive was also incorrect.

## First-time contributors

You **must** read and follow our [First-time contributors](https://6.docs.plone.org/contributing/first-time.html).

---

## Submit a pull request

Thank you for your contribution to the Plone Documentation.

Before submitting this pull request, please make sure you follow our guides:

-   [Contributing to Plone documentation](https://6.docs.plone.org/contributing/index.html)
-   [Building and checking the quality of documentation](https://6.docs.plone.org/contributing/setup-build.html)
-   [Authors guide](https://6.docs.plone.org/contributing/authors.html)
-   [MyST reference](https://6.docs.plone.org/contributing/myst-reference.html)

## Issue number

- Fixes #

## Description
Removed the problematic `{include}` directive in setup-build.md due to issues with GitHub preview. Manually copied the content from the file docs/_inc/_install-python-plone61.md into setup-build.md to ensure proper display and functionality. The path in the original `{include}` directive was also incorrect.



## Add screenshots or links to a preview of the changes
Before
![image](https://github.com/user-attachments/assets/f608beff-d125-468a-a447-9b29eee69107)

After
![image](https://github.com/user-attachments/assets/47aac012-8ee3-4f47-82da-187f9d831def)




<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1835.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->