### PR TITLE
Ignore https://www.gnu.org/ due to repeated linkcheck failures, even …

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ linkcheck_ignore = [
     r"https://browsersl.ist/#",
     # Ignore unreliable sites
     r"https://web.archive.org/",
+    r"https://www.gnu.org/",  # Consider removal when upgrading Sphinx
     r"http://z3c.pt",  # fluke where Sphinx interprets this as a URL
 ]
 linkcheck_allowed_redirects = {


### PR DESCRIPTION
…though the site is just fine.

A future upgrade in Sphinx might address some of the linkchecker issues.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1840.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->