### PR TITLE
Prepare for Plone 6.1 release

### DIFF
--- a/docs/admin-guide/install-buildout.md
+++ b/docs/admin-guide/install-buildout.md
@@ -31,14 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.0, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE60}}
-% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest".
-% -   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone60.md
+```{include} /_inc/_install-python-plone61.md
 ```
 
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,14 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.0, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE60}}
-% TODO: These instructions install Plone 6.0.x. Uncomment next line and change the subsequent include when Plone 6.1 is released and "latest".
-% -   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone60.md
+```{include} /_inc/_install-python-plone61.md
 ```
 
 
@@ -60,7 +58,7 @@ python3 -m venv venv
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
-venv/bin/pip install -c https://dist.plone.org/release/6.0-latest/constraints.txt Plone pipx
+venv/bin/pip install -c https://dist.plone.org/release/6.1-latest/constraints.txt Plone pipx
 ```
 
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-61.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-61.md
@@ -17,7 +17,7 @@ Some may require changes in your setup.
 
 ## Drop Python 3.8 and 3.9
 
-We only support Python 3.10, 3.11, and 3.12.
+We only support Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}.
 
 
 ## TinyMCE upgraded in Classic UI

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -441,7 +441,7 @@ def source_replace(app, docname, source):
 
 # Dict of replacements.
 source_replacements = {
-    "{PLONE_BACKEND_MINOR_VERSION}": "6.0",
+    "{PLONE_BACKEND_MINOR_VERSION}": "6.1",
 }
 
 # Finally, configure app attributes.

--- a/docs/install/create-project-cookieplone.md
+++ b/docs/install/create-project-cookieplone.md
@@ -136,7 +136,6 @@ Note that pip normalizes these names, so `plone.volto` and `plone-volto` are the
 ```
 
 ```console
-% pipx run cookieplone project
 ╭──────────────────────────────── cookieplone ────────────────────────────────╮
 │                                                                             │
 │                              .xxxxxxxxxxxxxx.                               │
@@ -171,7 +170,17 @@ Note that pip normalizes these names, so `plone.volto` and `plone-volto` are the
 You've downloaded /Users/stevepiercy/.cookiecutters/cookieplone-templates 
 before. Is it okay to delete and re-download it? [y/n] (y): 
 ╭─────────────────────────────── Plone Project ───────────────────────────────╮
+│                                                                             │
 │ Creating a new Plone Project                                                │
+│                                                                             │
+│ Sanity check results:                                                       │
+│                                                                             │
+│   - Cookieplone: ✓                                                          │
+│   - Python: ✓                                                               │
+│   - Node: ✓                                                                 │
+│   - git: ✓                                                                  │
+│   - Docker (optional): ✓                                                    │
+│                                                                             │
 ╰─────────────────────────────────────────────────────────────────────────────╯
   [1/17] Project Title (Project Title): 
   [2/17] Project Description (A new project using Plone 6.): 
@@ -180,9 +189,9 @@ before. Is it okay to delete and re-download it? [y/n] (y):
   [5/17] Author (Plone Foundation): 
   [6/17] Author E-mail (collective@plone.org): 
   [7/17] Should we use prerelease versions? (No): 
-  [8/17] Plone Version (6.0.13): 
-  [9/17] Volto Version (18.0.0-alpha.43):
-  [10/17] Python Package Name (project.title):
+  [8/17] Plone Version (6.1.0): 
+  [9/17] Volto Version (18.8.1): 
+  [10/17] Python Package Name (project.title): 
   [11/17] Volto Addon Name (volto-project-title): 
   [12/17] Language
     1 - English
@@ -214,10 +223,9 @@ before. Is it okay to delete and re-download it? [y/n] (y):
 │                                                                             │
 │ Summary:                                                                    │
 │                                                                             │
-│   - Plone version: 6.0.13                                                   │
-│   - Volto version: 18.0.0-alpha.43                                          │
-│   - Output folder:                                                          │
-│ <PATH_TO>/project-title                                                     │
+│   - Plone version: 6.1.0                                                    │
+│   - Volto version: 18.8.1                                                   │
+│   - Output folder: <PATH_TO>/project-title                                  │
 │                                                                             │
 │                                                                             │
 ╰─────────────────────────────────────────────────────────────────────────────╯

--- a/docs/install/create-project-cookieplone.md
+++ b/docs/install/create-project-cookieplone.md
@@ -67,8 +67,7 @@ Plone 6 has both hardware requirements and software prerequisites.
 ```{include} /_inc/_install-python-plone61.md
 ```
 
-Plone 6.0 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE60}}.
-However, Cookieplone does not support Python 3.9.
+Plone 6.1 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}.
 
 ```{warning}
 Python 3.9 will reach [end of life in October 2025](https://devguide.python.org/versions/).
@@ -132,7 +131,7 @@ See the cookiecutter's README for how to [Use options to avoid prompts](https://
 ```
 
 ```{important}
-For {guilabel}`Project Slug`, you must not use any of the Plone core package names listed in [`constraints.txt`](https://dist.plone.org/release/6.0-latest/constraints.txt).
+For {guilabel}`Project Slug`, you must not use any of the Plone core package names listed in [`constraints.txt`](https://dist.plone.org/release/6.1-latest/constraints.txt).
 Note that pip normalizes these names, so `plone.volto` and `plone-volto` are the same package.
 ```
 

--- a/docs/install/create-project.md
+++ b/docs/install/create-project.md
@@ -54,7 +54,7 @@ Plone 6.0 has both hardware requirements and software prerequisites.
 ```{include} ../volto/_inc/_install-operating-system.md
 ```
 
--   Python {{SUPPORTED_PYTHON_VERSIONS_PLONE60}}
+-   Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
 -   {term}`pipx`
 -   {term}`nvm`
 -   {term}`Node.js` LTS 20.x

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -47,7 +47,7 @@ Then choose one of the following installation methods.
 If you are following a [Plone training](https://training.plone.org/), it should specify which option to choose.
 
 {doc}`create-project-cookieplone`
-:   This is the recommended way to install Plone 6 for a new project with the Volto frontend.
+:   This is the recommended way to install Plone for a new project with the Volto frontend.
     Cookieplone requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}.
 
 {doc}`/admin-guide/install-buildout`

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -19,5 +19,6 @@ Plone has several components, each of which have their own upgrade guides:
 
 For Plone 6 the most relevant guides are:
 
+-   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-61`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-60`
 -   {doc}`../backend/upgrading/version-specific-migration/migrate-to-volto`

--- a/requirements-initial.txt
+++ b/requirements-initial.txt
@@ -1,5 +1,5 @@
 # requirements-initial.txt
-# From https://dist.plone.org/release/6-latest/constraints.txt
-pip==24.0
-setuptools==71.0.0
-wheel==0.43.0
+# From https://dist.plone.org/release/6.1.0/constraints.txt
+pip==24.3.1
+setuptools==75.6.0
+wheel==0.45.1


### PR DESCRIPTION
TODO:

- [x] After the release, we need to run `pipx run cookieplone project --no-input` and replace the current console output with the command's in `docs/install/create-project-cookieplone.md`.

Refs https://github.com/plone/Products.CMFPlone/issues/4101

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1845.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->