### PR TITLE
Use `6-latest` for the truly latest 6

### DIFF
--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -58,7 +58,7 @@ python3 -m venv venv
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
-venv/bin/pip install -c https://dist.plone.org/release/6.1-latest/constraints.txt Plone pipx
+venv/bin/pip install -c https://dist.plone.org/release/6-latest/constraints.txt Plone pipx
 ```
 
 

--- a/docs/install/create-project-cookieplone.md
+++ b/docs/install/create-project-cookieplone.md
@@ -131,7 +131,7 @@ See the cookiecutter's README for how to [Use options to avoid prompts](https://
 ```
 
 ```{important}
-For {guilabel}`Project Slug`, you must not use any of the Plone core package names listed in [`constraints.txt`](https://dist.plone.org/release/6.1-latest/constraints.txt).
+For {guilabel}`Project Slug`, you must not use any of the Plone core package names listed in [`constraints.txt`](https://dist.plone.org/release/6-latest/constraints.txt).
 Note that pip normalizes these names, so `plone.volto` and `plone-volto` are the same package.
 ```
 


### PR DESCRIPTION
- Thus we don't have to update it for 6.2 🥳

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1849.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->