### PR TITLE
Fix the livehtml file watcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,9 @@ livehtml: deps  ## Rebuild Sphinx documentation on changes, with live-reload in 
 	cd "$(DOCS_DIR)" && ${SPHINXAUTOBUILD} \
 		--ignore "*.swp" \
 		--port 8050 \
+		--watch volto \
+		--watch plone.api \
+		--watch plone.restapi \
 		-b html . "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 
 .PHONY: rtd-pr-preview


### PR DESCRIPTION
@sneridagh reported, and I verified during the Alpine Sprint, that when using `make livehtml`, any changes in the following symlinked paths...

```
volto
plone.api
plone.restapi
```

...would result in no changes detected, and therefore no live reload. This PR fixes that bug.

Note, this was working fine before, and even as recently as last week. There was a macOS update last week. It's unlikely to be related. Also if anyone recently set this up, it might not affect them.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1853.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->