### PR TITLE
Added windows support in install Plone with pip docs

### DIFF
--- a/docs/_inc/_install-operating-system1.md
+++ b/docs/_inc/_install-operating-system1.md
@@ -1,8 +1,0 @@
-An operating system that runs all the requirements mentioned. 
-Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or Windows Subsystem for Linux (WSL) on Windows. 
-A UNIX-based operating system is recommended.
-
-```{important} 
-Windows alone is not recommended because Plone has not been extensively tested on it.
-If you get Plone to run on Windows alone, please feel free to document and share your process.
-```

--- a/docs/_inc/_install-operating-system1.md
+++ b/docs/_inc/_install-operating-system1.md
@@ -1,0 +1,8 @@
+An operating system that runs all the requirements mentioned. 
+Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or {term}`Windows Subsystem for Linux` (WSL) on Windows. 
+A UNIX-based operating system is recommended.
+
+```{important
+Windows alone is not recommended because Plone has not been extensively tested on it.
+If you get Plone to run on Windows alone, please feel free to document and share your process.
+```

--- a/docs/_inc/_install-operating-system1.md
+++ b/docs/_inc/_install-operating-system1.md
@@ -1,8 +1,8 @@
 An operating system that runs all the requirements mentioned. 
-Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or {term}`Windows Subsystem for Linux` (WSL) on Windows. 
+Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or Windows Subsystem for Linux (WSL) on Windows. 
 A UNIX-based operating system is recommended.
 
-```{important
+```{important} 
 Windows alone is not recommended because Plone has not been extensively tested on it.
 If you get Plone to run on Windows alone, please feel free to document and share your process.
 ```

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,7 +31,7 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
-```{include} /_inc_/_install-operating-system1.md
+```{include} /_inc/_install-operating-system1.md
 ```
 
 -   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,8 +31,14 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
-```{include} /_inc/_install-operating-system1.md
-```
+-   An operating system that runs all the requirements mentioned. 
+Most UNIX-based operating systems are supported, including many Linux distributions, macOS, or Windows Subsystem for Linux (WSL) on Windows. 
+A UNIX-based operating system is recommended.
+
+```{important} 
+Windows alone is not recommended because Plone has not been extensively tested on it.
+If you get Plone to run on Windows alone, please feel free to document and share your process.
+``` 
 
 -   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -42,7 +42,7 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Installation
 
-Select a directory of your choice, and change it to your working directory.
+Select a directory of your choice, and change it to your working directory. Please ensure your working directory doesn't have spaces or special characters, ideally choose a simple diectory (eg. C:\ or E:\).
 
 ```shell
 mkdir -p <my_projects>/plone
@@ -55,11 +55,30 @@ Create a Python virtual environment.
 python3 -m venv venv
 ```
 
+Activate your virtual environment.
+
+```shell
+source venv/bin/activate
+```
+
+For Windows:
+
+```shell
+.\venv\Scripts\activate
+```
+
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
 venv/bin/pip install -c https://dist.plone.org/release/6-latest/constraints.txt Plone pipx
 ```
+
+For Windows:
+
+```shell
+.\venv\Scripts\pip install -c https://dist.plone.org/release/6-latest/constraints.txt Plone pipx
+```
+
 
 
 ## Create a Zope instance
@@ -86,6 +105,12 @@ Now run the {term}`cookiecutter` tool to create configuration for a Zope instanc
 bin/pipx run cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance
 ```
 
+For Windows(venv):
+
+```
+.\venv\Scripts pip install cookiecutter
+.\venv\Scripts\cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance
+```
 
 ## Start Plone in foreground mode
 
@@ -93,6 +118,12 @@ Start the instance for a quick test.
 
 ```shell
 bin/runwsgi -v instance/etc/zope.ini
+```
+
+For Windows(venv),
+
+```shell
+.\venv\Scripts\runwsgi -v instance/etc/zope.ini
 ```
 
 ```{include} /_inc/_create-classic-ui-instance.md

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,6 +31,9 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
+```{include} /_inc_/_install-operating-system1.md
+```
+
 -   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
 
 
@@ -55,30 +58,11 @@ Create a Python virtual environment.
 python3 -m venv venv
 ```
 
-Activate your virtual environment.
-
-```shell
-source venv/bin/activate
-```
-
-For Windows:
-
-```shell
-.\venv\Scripts\activate
-```
-
 Install Plone and a helper package, {term}`pipx`.
 
 ```shell
 venv/bin/pip install -c https://dist.plone.org/release/6-latest/constraints.txt Plone pipx
 ```
-
-For Windows:
-
-```shell
-.\venv\Scripts\pip install -c https://dist.plone.org/release/6-latest/constraints.txt Plone pipx
-```
-
 
 
 ## Create a Zope instance
@@ -90,7 +74,7 @@ default_context:
   initial_user_name: "admin"
 # Use a secure token for the password in a production environment.
   initial_user_password: "admin"
-  wsgi_listen: "localhost:8080"
+  wsgi_listen: "localhost:8080" 
   debug_mode: false
   verbose_security: false
   db_storage: "direct"
@@ -105,12 +89,6 @@ Now run the {term}`cookiecutter` tool to create configuration for a Zope instanc
 bin/pipx run cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance
 ```
 
-For Windows(venv):
-
-```
-.\venv\Scripts pip install cookiecutter
-.\venv\Scripts\cookiecutter -f --no-input --config-file instance.yaml gh:plone/cookiecutter-zope-instance
-```
 
 ## Start Plone in foreground mode
 
@@ -120,11 +98,6 @@ Start the instance for a quick test.
 bin/runwsgi -v instance/etc/zope.ini
 ```
 
-For Windows(venv),
-
-```shell
-.\venv\Scripts\runwsgi -v instance/etc/zope.ini
-```
 
 ```{include} /_inc/_create-classic-ui-instance.md
 ```


### PR DESCRIPTION
## Description
I made this contributing as I was trying to install Plone with pip on my Windows laptop to test its feature.  These are fixes to errors I faced along the way.

The command ```venv/bin/``` is for Linux/MacOS

For Windows it is ```.\venv\Scripts```

Plus I was facing issues with pipx run cookie cutter.
If you're already in a venv, you can install cookiecutter with pip, so I added instructions for that.

## Page which was modified 
https://6.docs.plone.org/admin-guide/install-pip.html



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1858.org.readthedocs.build/admin-guide/install-pip.html

<!-- readthedocs-preview plone6 end -->