### PR TITLE
Added reference guide for cookieplone-make-commands

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,12 @@ backend/index
 i18n-l10n/index
 conceptual-guides/index
 contributing/index
+reference-guide/index
+
+
+
+
+
 ```
 
 ```{toctree}

--- a/docs/reference-guide/cookieplone-make-commands.md
+++ b/docs/reference-guide/cookieplone-make-commands.md
@@ -1,0 +1,61 @@
+---
+myst:
+  html_meta:
+    "description": "Reference guide for all make commands used in Cookieplone."
+    "property=og:description": "Reference guide for all make commands used in Cookieplone."
+    "property=og:title": "Cookieplone Make Commands"
+    "keywords": "Plone 6, Reference Guide, Make Commands, Cookieplone"
+---
+
+# 🍪 Cookieplone Make Commands
+
+This page provides a reference guide for all `make` commands used in Cookieplone.
+
+## 🖥️ Frontend Commands
+
+- **`make frontend-install`** → Installs dependencies for the React frontend.  
+- **`make frontend-start`** → Starts the frontend development server.  
+- **`make frontend-build`** → Builds the React frontend for production.  
+- **`make frontend-test`** → Runs tests for the frontend.  
+
+## ⚙️ Backend Commands
+
+- **`make backend-install`** → Creates a virtual environment and installs Plone.  
+- **`make backend-start`** → Starts the Plone backend server.  
+- **`make backend-build`** → Builds the backend.  
+- **`make backend-test`** → Runs tests on the backend.  
+- **`make backend-create-site`** → Creates a new Plone site.  
+- **`make backend-update-example-content`** → Exports example content.  
+
+## 🐳 Docker Commands
+
+- **`make stack-start`** → Starts all services (Frontend + Backend) using Docker.  
+- **`make stack-stop`** → Stops all running services.  
+- **`make stack-status`** → Checks service status.  
+- **`make stack-create-site`** → Creates a new Plone site in Docker.  
+- **`make stack-rm`** → Removes all services and volumes.  
+- **`make build-images`** → Builds Docker images for the project.  
+
+## 🛠️ Utility Commands
+
+- **`make install`** → Runs both `backend-install` and `frontend-install`.  
+- **`make start`** → Starts the entire project.  
+- **`make test`** → Runs tests for both frontend and backend.  
+- **`make check`** → Formats and lints the entire codebase.  
+- **`make clean`** → Cleans temp files.  
+- **`make help`** → Shows available commands.  
+
+---
+
+### **📌 Notes**
+- Run **`make install`** before any `start` command to avoid missing dependencies.  
+- If using Docker, **use `make stack-start`** instead of manually starting frontend and backend.  
+
+📌 **Tip:** If you're unsure about a command, run `make help` to list all options.
+
+---
+
+### **🚀 Next Steps**
+Rebuild with:
+```sh
+make html

--- a/docs/reference-guide/index.md
+++ b/docs/reference-guide/index.md
@@ -1,0 +1,18 @@
+---
+myst:
+  html_meta:
+    "description": "Reference Guide for Plone, including important commands and configurations."
+    "property=og:description": "Reference Guide for Plone, including important commands and configurations."
+    "property=og:title": "Reference Guide"
+    "keywords": "Plone 6, Reference Guide, Cookieplone Make Commands"
+---
+
+# Reference Guide
+
+This section provides essential references for working with Plone.
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+cookieplone-make-commands


### PR DESCRIPTION
This PR adds a new Reference Guide for Cookieplone `make `commands under the docs/reference-guide/ section. It documents various make commands used in Cookieplone and organizes them by category.

Changes Introduced:

 Added: docs/reference-guide/cookieplone-make-commands.md

Categorized make commands into Frontend, Backend, Docker, and Utility Commands.

Provides descriptions for each command.

 Added: docs/reference-guide/index.md

Introduces the Reference Guide section.

 Modified: docs/index.md

Added a link to the Reference Guide so users can navigate to it easily.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1861.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->