### PR TITLE
Run plone  minor fixes

### DIFF
--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -101,3 +101,11 @@ pip:
     ```
 
 For any of these commands, press {kbd}`ctrl-d` to stop the process.
+
+### Set a "fake" request
+
+To make sure that the request is fully set up for any code that uses `zope.globalrequest.getRequest` you might need to do:
+:   ```python
+    from zope.globalrequest import setRequest
+    setRequest(app.REQUEST)
+    ```

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -107,6 +107,6 @@ For any of these commands, press {kbd}`ctrl-d` to stop the process.
 To make sure that the request is fully set up for any code that uses `zope.globalrequest.getRequest`, you might need to use the following code.
 
 ```python
-    from zope.globalrequest import setRequest
-    setRequest(app.REQUEST)
-    ```
+from zope.globalrequest import setRequest
+setRequest(app.REQUEST)
+```

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -107,6 +107,9 @@ For any of these commands, press {kbd}`ctrl-d` to stop the process.
 To make sure that the request is fully set up for any code that uses `zope.globalrequest.getRequest`, you might need to use the following code.
 
 ```python
+from Testing.makerequest import makerequest
 from zope.globalrequest import setRequest
+
+app = makerequest(app)
 setRequest(app.REQUEST)
 ```

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -92,7 +92,7 @@ Buildout:
 
 pip:
 :   ```shell
-    bin/zconsole debug instance/etc/zope.ini
+    bin/zconsole debug instance/etc/zope.conf
     ```
 
 `cookiecutter-plone-starter`:

--- a/docs/admin-guide/run-plone.md
+++ b/docs/admin-guide/run-plone.md
@@ -104,8 +104,9 @@ For any of these commands, press {kbd}`ctrl-d` to stop the process.
 
 ### Set a "fake" request
 
-To make sure that the request is fully set up for any code that uses `zope.globalrequest.getRequest` you might need to do:
-:   ```python
+To make sure that the request is fully set up for any code that uses `zope.globalrequest.getRequest`, you might need to use the following code.
+
+```python
     from zope.globalrequest import setRequest
     setRequest(app.REQUEST)
     ```


### PR DESCRIPTION
## Issue number

- Untracked

## Description

I think that the instructions about how to [run a debug console](https://6.docs.plone.org/admin-guide/run-plone.html#run-a-debug-console) with `pip` might be wrong. When using `zconsole` one probably need `zope.conf`, not `zope.ini`.

I'm also adding a note about `setRequest()` copied from https://community.plone.org/t/interactive-shell-for-debugging-with-plone-6-docker-compose-the-wsgi-equivalent-of-bin-instance-debug/16370/9?u=gamboz 




<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1872.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->