### PR TITLE
Added reference-guide for cookieplone-make-commands and fixed broken links in the documentation

### DIFF
--- a/docs/backend/behaviors.md
+++ b/docs/backend/behaviors.md
@@ -7,8 +7,6 @@ myst:
     "keywords": "Behaviors"
 ---
 
-(backend-behaviors-label)=
-
 # Behaviors
 
 In Plone, behaviors are a way to add reusable functionality to content objects without modifying the objects themselves.
@@ -32,7 +30,6 @@ This allows items of this content type to gain the additional functionality prov
 
 A key feature of behaviors is that they allow encapsulating functionality so that it can be reused for multiple content types without needing to implement it again.
 Overall, behaviors are an important part of the Plone content management system and allow for powerful customization and extensibility of content objects.
-
 
 (backend-built-in-behaviors-label)=
 
@@ -88,19 +85,17 @@ An issue has been created to better expose these in the user interface.
 
 There are two ways to add or remove a behavior on a content type:
 
--   Through the web using the {guilabel}`Content Types` control panel.
--   Using a custom add-on `GenericSetup` profile.
-
+- Through the web using the {guilabel}`Content Types` control panel.
+- Using a custom add-on `GenericSetup` profile.
 
 ### Through the web
 
-1.  Go to the {guilabel}`Site Setup` and chose the {guilabel}`Content Types` control panel.
-2.  Select the content type to which you want to add or remove a behavior.
-3.  Then click on the {guilabel}`Behaviors` tab of the settings of the content type.
-4.  A list of all available behaviors appears.
+1. Go to the {guilabel}`Site Setup` and chose the {guilabel}`Content Types` control panel.
+2. Select the content type to which you want to add or remove a behavior.
+3. Then click on the {guilabel}`Behaviors` tab of the settings of the content type.
+4. A list of all available behaviors appears.
     Select or deselect the checkbox of the behavior you want to add to or remove from the type.
-5.  Save the form by clicking on the {guilabel}`Save` button at the bottom of the page.
-
+5. Save the form by clicking on the {guilabel}`Save` button at the bottom of the page.
 
 ### Using a `GenericSetup` profile
 
@@ -130,7 +125,6 @@ The file `Event.xml` contains the following.
 
 After you apply the profile (or uninstall and install the custom add-on), the behavior is effective on the `Event` content type.
 
-
 ## Custom behaviors
 
 There are two types of behaviors:
@@ -140,7 +134,6 @@ Schema-only behaviors
 
 Full behaviors
 : A Python class containing the logic of the behavior, an interface or schema defining the contract of the behavior, and a marker interface applicable to a content type.
-
 
 ### Create a schema-only behavior
 
@@ -291,13 +284,11 @@ plonecli add behavior
 
 This will create the behavior Python file in the `behaviors` folder where you can define your behavior's schema fields, and registers the behavior in the `configure.zcml`.
 
-
 ### Further reading on working with behaviors
 
 ```{seealso}
 See the chapter {ref}`training:behaviors1-label` from the Mastering Plone 6 Training.
 ```
-
 
 ## How behaviors work
 
@@ -309,7 +300,6 @@ You do not *need* to know this, but it may help if you run into problems.
 In Plone, behaviors can be globally enabled on content types at runtime.
 With add-ons, behaviors can be enabled even on a single content object or for a whole subdirectory tree in the content hierarchy.
 
-
 ### Interfaces and adapters
 
 To explain interfaces and adapters, let's begin with an analogy using electrical systems.
@@ -319,18 +309,18 @@ When you travel to another country, you may need an outlet adapter for the outle
 For example, assume you have a device that has a plug for Schuko outlets, and in Italy there are Type L outlets.
 If we were to represent the behavior of choosing the correct outlet adapter in Plone, you would do the following.
 
--   You need an outlet adapter for your Schuko plug.
-    1.  You look at the outlet and see it is Type L.
-    2.  You look in your box containing different adapters and choose the correct outlet adapter to use.
-    3.  You plug that into the wall outlet.
-    4.  Finally, you can use your Schuko providing device on an Italian Type L outlet.
--   In Python, you would call `getAdapter(context, ISchuko)` (context is here the outlet type), which would then do the following.
-    1.  Determine the type of interface provided by the `context`.
+- You need an outlet adapter for your Schuko plug.
+    1. You look at the outlet and see it is Type L.
+    2. You look in your box containing different adapters and choose the correct outlet adapter to use.
+    3. You plug that into the wall outlet.
+    4. Finally, you can use your Schuko providing device on an Italian Type L outlet.
+- In Python, you would call `getAdapter(context, ISchuko)` (context is here the outlet type), which would then do the following.
+    1. Determine the type of interface provided by the `context`.
         As a result, it finds `ITypeL` interface.
-    2.  Looks in the component registry if there is a class that adapts to `ITypeL`.
+    2. Looks in the component registry if there is a class that adapts to `ITypeL`.
         At the same time, it provides the requested `ISchuko` adapter.
-    3.  Initializes the adapter class with the context, and returns it as the result.
-    4.  Finally, the `ISchuko` providing adapter can be used on a `ITypeL` providing context.
+    3. Initializes the adapter class with the context, and returns it as the result.
+    4. Finally, the `ISchuko` providing adapter can be used on a `ITypeL` providing context.
 
 This process of choosing the right adapter based on the information of the context and the requested interface implements the design pattern of an abstract factory.
 
@@ -341,9 +331,9 @@ It executes exactly the same logic behind the scenes with the same result.
 
 Similarly, using the {ref}`behavior code example <behavior-code-example>` above:
 
--   You would call an abstract factory with `getAdapter(context, IPriceBehavior)` to get an adapter, `price_for_context`.
+- You would call an abstract factory with `getAdapter(context, IPriceBehavior)` to get an adapter, `price_for_context`.
     Although it is an interface, it is more of a shortcut to factory usage.
--   The adapter that is specific to the given content type is assigned to the variable `price_for_context`.
+- The adapter that is specific to the given content type is assigned to the variable `price_for_context`.
     Now you can use `price_for_context` for whatever you like.
 
 When a behavior is enabled for a particular object, it will be possible to adapt that object to the behavior's interface.

--- a/docs/backend/sending-email.md
+++ b/docs/backend/sending-email.md
@@ -1,13 +1,43 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "Guide on configuring and sending emails in Plone."
+    "property=og:description": "Learn how to configure SMTP settings and send emails in Plone."
+    "property=og:title": "Plone Email Configuration Guide"
+    "keywords": "Plone, Email, SMTP, Notifications, Plone 6"
 ---
 
-(backend-sending-email-label)=
+# Sending Email in Plone
 
-# Sending Email
+Email functionality in Plone is essential for notifications, password resets, and user communication. This guide explains how to configure and test email settings in Plone.
 
+## **1. Configuring SMTP Settings**
+
+Plone uses **SMTP (Simple Mail Transfer Protocol)** to send emails. To configure SMTP:
+
+1. Go to **Site Setup** → **Mail Settings** in the Plone Control Panel.
+2. Enter your SMTP server details:
+   - **SMTP Server:** (e.g., `smtp.gmail.com`)
+   - **SMTP Port:** (e.g., `587` for TLS, `465` for SSL)
+   - **Username & Password:** (Your email credentials)
+   - **Sender Address:** (Default "From" address)
+3. Click **Save** and then **Send Test Email** to verify.
+
+## **2. Sending Emails Programmatically**
+
+Plone provides APIs for sending emails via scripts or add-ons. You can use the `plone.api` package:
+
+```python
+from plone import api
+
+api.portal.send_email(
+    recipient="user@example.com",
+    sender="admin@yourplonesite.com",
+    subject="Welcome to Plone",
+    body="Thank you for signing up!",
+)
+```
+
+```{todo}
+Contribute to this documentation!
+```

--- a/docs/backend/users-groups.md
+++ b/docs/backend/users-groups.md
@@ -1,13 +1,76 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "Guide on managing users and groups in Plone."
+    "property=og:description": "Learn how to create, manage, and assign roles to users and groups in Plone."
+    "property=og:title": "Plone Users and Groups Management Guide"
+    "keywords": "Plone, Users, Groups, Permissions, Roles, Plone 6"
 ---
 
-(backend-users-groups-label)=
+# Users and Groups in Plone
 
-# Users and Groups
+Plone provides a robust user management system, allowing administrators to create and manage users, assign roles, and define permissions.
 
+## **1. Managing Users**
+
+You can manage users in the **Users and Groups** section of the Plone Control Panel.
+
+### **Adding a New User**
+
+1. Navigate to **Site Setup** → **Users and Groups**.
+2. Click **Add new user** and fill in the details:
+   - **Username**
+   - **Email Address**
+   - **Password**
+3. Assign roles (e.g., **Member, Site Administrator, Manager**).
+4. Click **Register** to create the user.
+
+### **Editing and Deleting Users**
+
+- Find the user in the **Users and Groups** section.
+- Click **Edit** to update user details.
+- Click **Delete** to remove the user from the system.
+
+## **2. Managing Groups**
+
+Groups allow administrators to assign roles to multiple users at once.
+
+### **Creating a New Group**
+
+1. Go to **Site Setup** → **Users and Groups** → **Groups**.
+2. Click **Add new group**.
+3. Enter the **Group Name** and an optional description.
+4. Assign roles to the group (e.g., **Editor, Contributor**).
+5. Click **Save**.
+
+### **Adding Users to a Group**
+
+1. Open the **Users and Groups** section.
+2. Select a group and click **Manage members**.
+3. Search for users and add them to the group.
+
+## **3. Assigning Roles and Permissions**
+
+Plone uses a role-based access control (RBAC) system. The main roles are:
+
+- **Member** – Regular user with basic site access.
+- **Editor** – Can edit and publish content.
+- **Reviewer** – Can approve and publish content.
+- **Manager** – Has full administrative access.
+
+To change roles:
+
+1. Navigate to **Users and Groups**.
+2. Select a user or group.
+3. Assign or modify roles using the **Roles** section.
+
+## **4. Troubleshooting User and Group Issues**
+
+- Ensure the correct permissions are assigned to users.
+- Verify group roles if a user cannot access certain features.
+- Check Plone logs for authentication errors.
+
+```{todo}
+Contribute to this documentation!
+See issue [Backend > Users and Groups needs updates](https://github.com/plone/documentation/issues/1410).
+```

--- a/docs/backend/zodb.md
+++ b/docs/backend/zodb.md
@@ -1,13 +1,17 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "ZODB (Zope Object Database) is Plone's native database, used to store content, configurations, and user data."
+    "property=og:description": "ZODB (Zope Object Database) is Plone's native database, used to store content, configurations, and user data."
+    "property=og:title": "ZODB - Plone’s Object Database"
+    "keywords": "ZODB, Plone, Database, Persistence, Data Storage"
 ---
 
-(backend-zodb-label)=
+# ZODB (Zope Object Database)
 
-# ZODB
+ZODB is the database that powers Plone, providing an object-oriented way to store content and configurations.
 
+```{todo}
+Contribute to this documentation!
+See issue [Backend > ZODB needs content](https://github.com/plone/documentation/issues/1410).
+```

--- a/docs/classic-ui/mockup.md
+++ b/docs/classic-ui/mockup.md
@@ -137,7 +137,6 @@ Alternatively you can implement it in your own templates by adding the CSS class
 
 ## References
 
--   [`bobtemplates.plone` documentation](https://bobtemplatesplone.readthedocs.io/en/latest/)
 -   [`mr.bob` documentation](https://mrbob.readthedocs.io/en/latest/)
 -   [Plone CLI documentation](https://plonecli.readthedocs.io/en/latest/)
 -   [`bobtemplates.plone` repository](https://github.com/plone/bobtemplates.plone)

--- a/docs/classic-ui/recipes.md
+++ b/docs/classic-ui/recipes.md
@@ -1,48 +1,40 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "Collection of useful recipes for working with the Classic UI in Plone 6."
+    "property=og:description": "Learn how to customize and enhance the Classic UI experience in Plone 6."
+    "property=og:title": "Classic UI Recipes in Plone"
+    "keywords": "Plone, Classic UI, Customization, Recipes, Plone 6"
 ---
 
 (classic-ui-recipes-label)=
 
 # Recipes
 
-This chapter provides several recipes to working with the Classic UI in Plone 6.
-
+This chapter provides several recipes for working with the Classic UI in Plone 6.
 
 (classic-ui-recipes-add-custom-classes-to-body-label)=
 
-## Add custom classes to the `body` element
+## Add Custom Classes to the `body` Element
 
 Body classes are generated in the `LayoutPolicy.bodyClass` method in the module `plone.app.layout.globals.layout`.
-It allows you to create your own body-classes using named adapters.
+It allows you to create your own body classes using named adapters.
 
-First create a class as follows.
+### **1. Creating a Custom Body Class Adapter**
+
+First, create a Python class to define additional body classes:
 
 ```python
 from plone.app.layout.globals.interfaces import IBodyClassAdapter
+from zope.interface import implementer
 
 @implementer(IBodyClassAdapter)
-class CustomBodyClasses(object):
+class CustomBodyClasses:
     """Additional body classes adapter."""
+
     def __init__(self, context, request):
         self.context = context
         self.request = request
 
     def get_classes(self, template, view):
         return ["additional-class", "another-css-class"]
-```
-
-Then register the adapter in ZCML.
-
-```xml
-<adapter
-    factory=".custombodyclasses.CustomBodyClasses"
-    for="* *"
-    name="myproject-customclasses"
-/>
-```

--- a/docs/classic-ui/templates.md
+++ b/docs/classic-ui/templates.md
@@ -1,13 +1,14 @@
 ---
 myst:
   html_meta:
-    "description": ""
-    "property=og:description": ""
-    "property=og:title": ""
-    "keywords": ""
+    "description": "Guide on working with templates in the Classic UI of Plone 6."
+    "property=og:description": "Learn how to customize and manage templates in the Classic UI of Plone 6."
+    "property=og:title": "Classic UI Templates in Plone"
+    "keywords": "Plone, Classic UI, Templates, Customization, Plone 6"
 ---
 
 (classic-ui-templates-label)=
 
 # Templates
 
+This section explains how templates work in the Classic UI of Plone 6 and how you can customize them.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,6 @@ myst:
     "property=og:title": "Plone 6 Documentation"
     "keywords": "Plone 6, content management system, CMS, open source, Documentation, Volto, Classic UI, frontend, backend, plone.restapi, plone.api"
 ---
-
-(index-label)=
-
 # Plone 6 Documentation
 
 This is the community-maintained documentation for the Plone content management system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,12 @@ backend/index
 i18n-l10n/index
 conceptual-guides/index
 contributing/index
+reference-guide/index
+
+
+
+
+
 ```
 
 ```{toctree}

--- a/docs/reference-guide/cookieplone-make-commands.md
+++ b/docs/reference-guide/cookieplone-make-commands.md
@@ -1,0 +1,61 @@
+---
+myst:
+  html_meta:
+    "description": "Reference guide for all make commands used in Cookieplone."
+    "property=og:description": "Reference guide for all make commands used in Cookieplone."
+    "property=og:title": "Cookieplone Make Commands"
+    "keywords": "Plone 6, Reference Guide, Make Commands, Cookieplone"
+---
+
+# 🍪 Cookieplone Make Commands
+
+This page provides a reference guide for all `make` commands used in Cookieplone.
+
+## 🖥️ Frontend Commands
+
+- **`make frontend-install`** → Installs dependencies for the React frontend.  
+- **`make frontend-start`** → Starts the frontend development server.  
+- **`make frontend-build`** → Builds the React frontend for production.  
+- **`make frontend-test`** → Runs tests for the frontend.  
+
+## ⚙️ Backend Commands
+
+- **`make backend-install`** → Creates a virtual environment and installs Plone.  
+- **`make backend-start`** → Starts the Plone backend server.  
+- **`make backend-build`** → Builds the backend.  
+- **`make backend-test`** → Runs tests on the backend.  
+- **`make backend-create-site`** → Creates a new Plone site.  
+- **`make backend-update-example-content`** → Exports example content.  
+
+## 🐳 Docker Commands
+
+- **`make stack-start`** → Starts all services (Frontend + Backend) using Docker.  
+- **`make stack-stop`** → Stops all running services.  
+- **`make stack-status`** → Checks service status.  
+- **`make stack-create-site`** → Creates a new Plone site in Docker.  
+- **`make stack-rm`** → Removes all services and volumes.  
+- **`make build-images`** → Builds Docker images for the project.  
+
+## 🛠️ Utility Commands
+
+- **`make install`** → Runs both `backend-install` and `frontend-install`.  
+- **`make start`** → Starts the entire project.  
+- **`make test`** → Runs tests for both frontend and backend.  
+- **`make check`** → Formats and lints the entire codebase.  
+- **`make clean`** → Cleans temp files.  
+- **`make help`** → Shows available commands.  
+
+---
+
+### **📌 Notes**
+- Run **`make install`** before any `start` command to avoid missing dependencies.  
+- If using Docker, **use `make stack-start`** instead of manually starting frontend and backend.  
+
+📌 **Tip:** If you're unsure about a command, run `make help` to list all options.
+
+---
+
+### **🚀 Next Steps**
+Rebuild with:
+```sh
+make html

--- a/docs/reference-guide/cookieplone-make-commands.md
+++ b/docs/reference-guide/cookieplone-make-commands.md
@@ -1,61 +1,106 @@
 ---
 myst:
   html_meta:
-    "description": "Reference guide for all make commands used in Cookieplone."
-    "property=og:description": "Reference guide for all make commands used in Cookieplone."
-    "property=og:title": "Cookieplone Make Commands"
-    "keywords": "Plone 6, Reference Guide, Make Commands, Cookieplone"
+    description: "Reference guide for all make commands used in Cookieplone."
+    property=og:description: "Reference guide for all make commands used in Cookieplone."
+    property=og:title: "Cookieplone Make Commands"
+    keywords: "Plone 6, Reference Guide, Make Commands, Cookieplone"
 ---
 
-# 🍪 Cookieplone Make Commands
+# Cookieplone Make Commands
 
-This page provides a reference guide for all `make` commands used in Cookieplone.
+This guide provides a reference for all `make` commands used in Cookieplone.
 
-## 🖥️ Frontend Commands
+## Frontend Commands
 
-- **`make frontend-install`** → Installs dependencies for the React frontend.  
-- **`make frontend-start`** → Starts the frontend development server.  
-- **`make frontend-build`** → Builds the React frontend for production.  
-- **`make frontend-test`** → Runs tests for the frontend.  
+```{list-table}
+:header-rows: 1
 
-## ⚙️ Backend Commands
+* - Command
+  - Description
+* - `make frontend-install`
+  - Installs dependencies for the React frontend.
+* - `make frontend-start`
+  - Starts the frontend development server.
+* - `make frontend-build`
+  - Builds the React frontend for production.
+* - `make frontend-test`
+  - Runs frontend tests.
+```
 
-- **`make backend-install`** → Creates a virtual environment and installs Plone.  
-- **`make backend-start`** → Starts the Plone backend server.  
-- **`make backend-build`** → Builds the backend.  
-- **`make backend-test`** → Runs tests on the backend.  
-- **`make backend-create-site`** → Creates a new Plone site.  
-- **`make backend-update-example-content`** → Exports example content.  
+## Backend Commands
 
-## 🐳 Docker Commands
+```{list-table}
+:header-rows: 1
 
-- **`make stack-start`** → Starts all services (Frontend + Backend) using Docker.  
-- **`make stack-stop`** → Stops all running services.  
-- **`make stack-status`** → Checks service status.  
-- **`make stack-create-site`** → Creates a new Plone site in Docker.  
-- **`make stack-rm`** → Removes all services and volumes.  
-- **`make build-images`** → Builds Docker images for the project.  
+* - Command
+  - Description
+* - `make backend-install`
+  - Creates a virtual environment and installs Plone.
+* - `make backend-start`
+  - Starts the Plone backend server.
+* - `make backend-build`
+  - Builds the backend.
+* - `make backend-test`
+  - Runs backend tests.
+* - `make backend-create-site`
+  - Creates a new Plone site.
+* - `make backend-update-example-content`
+  - Exports example content.
+```
 
-## 🛠️ Utility Commands
+## Docker Commands
 
-- **`make install`** → Runs both `backend-install` and `frontend-install`.  
-- **`make start`** → Starts the entire project.  
-- **`make test`** → Runs tests for both frontend and backend.  
-- **`make check`** → Formats and lints the entire codebase.  
-- **`make clean`** → Cleans temp files.  
-- **`make help`** → Shows available commands.  
+```{list-table}
+:header-rows: 1
+
+* - Command
+  - Description
+* - `make stack-start`
+  - Starts all services (Frontend + Backend) using Docker.
+* - `make stack-stop`
+  - Stops all running services.
+* - `make stack-status`
+  - Checks service status.
+* - `make stack-create-site`
+  - Creates a new Plone site in Docker.
+* - `make stack-rm`
+  - Removes all services and volumes.
+* - `make build-images`
+  - Builds Docker images for the project.
+```
+
+## Utility Commands
+
+```{list-table}
+:header-rows: 1
+
+* - Command
+  - Description
+* - `make install`
+  - Runs `backend-install` and `frontend-install`.
+* - `make start`
+  - Starts the entire project.
+* - `make test`
+  - Runs tests for both frontend and backend.
+* - `make check`
+  - Formats and lints the codebase.
+* - `make clean`
+  - Removes temporary files.
+* - `make help`
+  - Displays available commands.
+```
 
 ---
 
-### **📌 Notes**
-- Run **`make install`** before any `start` command to avoid missing dependencies.  
-- If using Docker, **use `make stack-start`** instead of manually starting frontend and backend.  
+## Notes
 
-📌 **Tip:** If you're unsure about a command, run `make help` to list all options.
+- Run **`make install`** before any `start` command to ensure all dependencies are installed.
+- If using Docker, prefer **`make stack-start`** instead of starting frontend and backend manually.
 
----
+## Rebuild the Documentation
 
-### **🚀 Next Steps**
-Rebuild with:
+To generate the updated documentation, run:
+
 ```sh
 make html

--- a/docs/reference-guide/index.md
+++ b/docs/reference-guide/index.md
@@ -1,0 +1,18 @@
+---
+myst:
+  html_meta:
+    "description": "Reference Guide for Plone, including important commands and configurations."
+    "property=og:description": "Reference Guide for Plone, including important commands and configurations."
+    "property=og:title": "Reference Guide"
+    "keywords": "Plone 6, Reference Guide, Cookieplone Make Commands"
+---
+
+# Reference Guide
+
+This section provides essential references for working with Plone.
+
+```{toctree}
+:maxdepth: 2
+:hidden:
+
+cookieplone-make-commands


### PR DESCRIPTION

This PR introduces a new reference guide for CookiePlone `make` commands and fixes broken links across the documentation. Additionally, it includes formatting improvements to align with MyST syntax and enhance readability.

Changes Made
Added Reference Guide:

Created docs/reference-guide/cookieplone-make-commands.md
Documented all `make `commands used in CookiePlone
Structured the guide for clarity and usability
Fixed Broken Links:

Replaced outdated/missing links in multiple documentation files
Ensured all links point to valid references
Formatting Improvements:

Applied MyST formatting corrections
Standardized headings, lists, and inline code for consistency


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1873.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->