### PR TITLE
Update corepack enable to latest approach

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -312,7 +312,6 @@ Corepack
     In practical terms, Corepack lets you use {term}`Yarn`, {term}`npm`, and {term}`pnpm` without having to install them.
 
     Corepack is distributed by default with all recent Node.js versions.
-    Run `npm i -g corepack@latest && corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 Git
     [Git](https://git-scm.com/) is a free and open source distributed version control system.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -312,7 +312,7 @@ Corepack
     In practical terms, Corepack lets you use {term}`Yarn`, {term}`npm`, and {term}`pnpm` without having to install them.
 
     Corepack is distributed by default with all recent Node.js versions.
-    Run `corepack enable` to install the required Yarn and pnpm binaries on your path.
+    Run `npm i -g corepack@latest && corepack enable` to install the required Yarn and pnpm binaries on your path.
 
 Git
     [Git](https://git-scm.com/) is a free and open source distributed version control system.

--- a/docs/install/create-project-cookieplone.md
+++ b/docs/install/create-project-cookieplone.md
@@ -98,7 +98,7 @@ Do not create a new Plone project with Python 3.9.
 3.  Enable {term}`corepack` so that Node.js will install {term}`pnpm` as a package manager.
 
     ```shell
-    corepack enable
+    npm i -g corepack@latest && corepack enable
     ```
 
 

--- a/docs/install/create-project.md
+++ b/docs/install/create-project.md
@@ -117,7 +117,7 @@ Use {term}`Corepack` to enable Yarn, which was already installed with the {ref}`
 1.  Open a terminal and type:
 
     ```shell
-    corepack enable
+    npm i -g corepack@latest && corepack enable
     ```
 
 ````{important}

--- a/docs/install/create-project.md
+++ b/docs/install/create-project.md
@@ -117,7 +117,7 @@ Use {term}`Corepack` to enable Yarn, which was already installed with the {ref}`
 1.  Open a terminal and type:
 
     ```shell
-    npm i -g corepack@latest && corepack enable
+    corepack enable
     ```
 
 ````{important}


### PR DESCRIPTION
## Issue number

- Fixes #1877 

## Description

Updated all occurences of `corepack enable` to `npm i -g corepack@latest && corepack enable`

## Add screenshots or links to a preview of the changes



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1879.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->