### PR TITLE
Remove `linkcheck_report_timeouts_as_broken` setting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -116,8 +116,6 @@ linkcheck_allowed_redirects = {
 linkcheck_anchors = True
 linkcheck_timeout = 5
 linkcheck_retries = 1
-# See https://github.com/plone/documentation/issues/1815
-linkcheck_report_timeouts_as_broken = False
 
 # The suffix of source filenames.
 source_suffix = {


### PR DESCRIPTION
Remove `linkcheck_report_timeouts_as_broken` setting. We're now using Sphinx 8, which has this set to `False` by default. Closes #1815.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1904.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->