### PR TITLE
Fix Makefile dependencies for installing plone.api

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,7 +18,7 @@ build:
     # If there are no changes (git diff exits with 0) we force the command to return with 183.
     # This is a special exit code on Read the Docs that will cancel the build immediately.
     - |
-      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/6.0 -- docs/ .readthedocs.yaml requirements-initial.txt requirements.txt;
+      if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/6.0 -- docs/ Makefile .readthedocs.yaml requirements-initial.txt requirements.txt;
       then
         exit 183;
       fi

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,14 @@ venv/bin/python:  ## Setup up Python virtual environment and install requirement
 docs/plone.api:  ## Setup plone.api docs
 	git submodule init
 	git submodule update
-	venv/bin/pip install -e submodules/plone.api/"[test]"
 	ln -s ../submodules/plone.api/docs ./docs/plone.api
 	@echo
 	@echo "Documentation of plone.api initialized."
+
+.PHONY: install-api
+install-api: docs/plone.api
+	venv/bin/pip install plone.api -c submodules/plone.api/constraints.txt
+	venv/bin/pip install --no-deps -e submodules/plone.api/"[test]"
 
 docs/plone.restapi:  ## Setup plone.restapi docs
 	git submodule init
@@ -68,8 +72,7 @@ docs/volto:  ## Setup Volto docs
 	@echo "Documentation of volto initialized."
 
 .PHONY: deps
-deps: venv/bin/python docs/volto docs/plone.restapi docs/plone.api  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, and finally create symlinks to the source files.
-
+deps: venv/bin/python docs/volto docs/plone.restapi install-api  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, and finally create symlinks to the source files.
 
 .PHONY: html
 html: deps  ## Build html

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ rtd-pr-preview:  ## Build pull request preview on Read the Docs
 	pip install -r requirements.txt
 	git submodule init
 	git submodule update
-	pip install -e submodules/plone.api[test]
+	pip install plone.api -c submodules/plone.api/constraints.txt
+	pip install --no-deps -e submodules/plone.api[test]
 	ln -s ../submodules/volto/docs/source ./docs/volto
 	ln -s ../submodules/plone.restapi ./docs/plone.restapi
 	ln -s ../submodules/plone.api/docs ./docs/plone.api


### PR DESCRIPTION
Fixes #1906.

The command to install plone.api was not run if the plone.api submodule was already initialized.

There's a bit of a trick with the installation: first we install the released version of plone.api with constraints.txt to make sure we get a known good set of Plone packages (rather than simply the latest version of each package) and then we do an editable install from the submodule with `--no-deps`, to make sure we have the right version of plone.api without pip complaining about its version not matching the constraints.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1907.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->