### PR TITLE
touch `plone.api-install` to avoid running pip repeatedly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,5 @@ docs/plone.api
 docs/plone.restapi
 docs/volto
 
-# created on first make command
-plone.api-install
-
 # editor files
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -35,22 +35,22 @@ distclean: clean ## Clean docs build directory, Python virtual environment, and 
 	rm docs/plone.api
 	rm docs/plone.restapi
 	rm docs/volto
-	@echo
 	@echo "Cleaned docs build directory, Python virtual environment, and symlinks."
+	@echo
 
 venv/bin/python:  ## Setup up Python virtual environment and install requirements
 	python3 -m venv venv
 	venv/bin/pip install -r requirements-initial.txt
 	venv/bin/pip install -r requirements.txt
-	@echo
 	@echo "Installation of requirements completed."
+	@echo
 
 docs/plone.api:  ## Setup plone.api docs
 	git submodule init
 	git submodule update
 	ln -s ../submodules/plone.api/docs ./docs/plone.api
-	@echo
 	@echo "Documentation of plone.api initialized."
+	@echo
 
 plone.api-install: docs/plone.api
 	touch plone.api-install
@@ -63,15 +63,15 @@ docs/plone.restapi:  ## Setup plone.restapi docs
 	git submodule init
 	git submodule update
 	ln -s ../submodules/plone.restapi ./docs/plone.restapi
-	@echo
 	@echo "Documentation of plone.restapi initialized."
+	@echo
 
 docs/volto:  ## Setup Volto docs
 	git submodule init
 	git submodule update
 	ln -s ../submodules/volto/docs/source ./docs/volto
-	@echo
 	@echo "Documentation of volto initialized."
+	@echo
 
 .PHONY: deps
 deps: venv/bin/python docs/volto docs/plone.restapi plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
@@ -79,57 +79,59 @@ deps: venv/bin/python docs/volto docs/plone.restapi plone.api-install  ## Create
 .PHONY: html
 html: deps  ## Build html
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo
 
 .PHONY: manual
 manual: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b html -t manual . $(BUILDDIR)/manual
+	@echo "Build finished. The manual pages are in $(BUILDDIR)/manual."
+	@echo
 
 .PHONY: dirhtml
 dirhtml: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
-	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
+	@echo
 
 .PHONY: singlehtml
 singlehtml: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
-	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
+	@echo
 
 .PHONY: pickle
 pickle: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
-	@echo
 	@echo "Build finished; now you can process the pickle files."
+	@echo
 
 .PHONY: json
 json: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
-	@echo
 	@echo "Build finished; now you can process the JSON files."
+	@echo
 
 .PHONY: htmlhelp
 htmlhelp: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
-	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
+	@echo
 
 .PHONY: epub
 epub: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
+	@echo
 
 .PHONY: latex
 latex: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
 	@echo "Run \`make' in that directory to run these through (pdf)latex" \
 	      "(use \`make latexpdf' here to do that automatically)."
+	@echo
 
 .PHONY: latexpdf
 latexpdf: deps
@@ -137,26 +139,27 @@ latexpdf: deps
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
+	@echo
 
 .PHONY: text
 text: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
-	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
+	@echo
 
 .PHONY: man
 man: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
-	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
+	@echo
 
 .PHONY: texinfo
 texinfo: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
 	@echo "Run \`make' in that directory to run these through makeinfo" \
 	      "(use \`make info' here to do that automatically)."
+	@echo
 
 .PHONY: info
 info: deps
@@ -164,33 +167,34 @@ info: deps
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
+	@echo
 
 .PHONY: changes
 changes: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
-	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
+	@echo
 
 .PHONY: linkcheck
 linkcheck: deps  ## Run linkcheck
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 		"or in $(BUILDDIR)/linkcheck/ ."
+	@echo
 
 .PHONY: linkcheckbroken
 linkcheckbroken: deps  ## Run linkcheck and show only broken links
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck | GREP_COLORS='0;31' grep -wi "broken\|redirect" --color=always | GREP_COLORS='0;31' grep -vi "https://github.com/plone/volto/issues/" --color=always && if test $$? = 0; then exit 1; fi || test $$? = 1
-	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 		"or in $(BUILDDIR)/linkcheck/ ."
+	@echo
 
 .PHONY: vale
 vale: deps  ## Run Vale style, grammar, and spell checks
 	venv/bin/vale sync
 	venv/bin/vale --no-wrap $(VALEOPTS) $(VALEFILES)
-	@echo
 	@echo "Vale is finished; look for any errors in the above output."
+	@echo
 
 .PHONY: html_meta
 html_meta: deps  ## Add meta data headers to all Markdown pages
@@ -201,6 +205,7 @@ doctest: deps
 	cd $(DOCS_DIR) && $(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+	@echo
 
 .PHONY: test
 test: clean linkcheckbroken  ## Clean docs build, then run linkcheckbroken

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ docs/plone.api:  ## Setup plone.api docs
 	@echo "Documentation of plone.api initialized."
 	@echo
 
-plone.api-install: docs/plone.api
-	touch plone.api-install
+venv/plone.api-install: docs/plone.api
+	touch venv/plone.api-install
 	venv/bin/pip install plone.api -c submodules/plone.api/constraints.txt
 	venv/bin/pip install --no-deps -e submodules/plone.api/"[test]"
 	@echo "plone.api installed."
@@ -74,7 +74,7 @@ docs/volto:  ## Setup Volto docs
 	@echo
 
 .PHONY: deps
-deps: venv/bin/python docs/volto docs/plone.restapi plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
+deps: venv/bin/python docs/volto docs/plone.restapi venv/plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
 
 .PHONY: html
 html: deps  ## Build html

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,12 @@ docs/plone.api:  ## Setup plone.api docs
 	@echo
 	@echo "Documentation of plone.api initialized."
 
-.PHONY: install-api
-install-api: docs/plone.api
+plone.api-install: docs/plone.api
+	touch plone.api-install
 	venv/bin/pip install plone.api -c submodules/plone.api/constraints.txt
 	venv/bin/pip install --no-deps -e submodules/plone.api/"[test]"
+	@echo "plone.api installed."
+	@echo
 
 docs/plone.restapi:  ## Setup plone.restapi docs
 	git submodule init
@@ -72,7 +74,7 @@ docs/volto:  ## Setup Volto docs
 	@echo "Documentation of volto initialized."
 
 .PHONY: deps
-deps: venv/bin/python docs/volto docs/plone.restapi install-api  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, and finally create symlinks to the source files.
+deps: venv/bin/python docs/volto docs/plone.restapi plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
 
 .PHONY: html
 html: deps  ## Build html


### PR DESCRIPTION
When there is a separate target to only install `plone.api`, it runs pip every time to see if it is installed, which can take a second or two. It's an annoyance that adds up.

So I modified the Makefile to fake it, by making the target `plone.api-install` create a file with the same name. Make will skip that target's commands when a file with the name of the target exists, and, of course, it's not a phony target.

On the first run, `plone.api-install` will create the file `plone.api-install` and install plone.api. On subsequent runs, since a file with the name of the target exists, the target will be skipped.

If you want to purge the installation, use `make distclean`.

Also moved `@echo`s to the last command for each target to make it easier to see its final statement and to group it together in the console.

Note: while coming up with this, I was listening to the Peter Gabriel Live album, "I Have the Touch". Subliminal messages... 🤯

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1910.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->