### PR TITLE
Fix reference to target `create-project-cookieplone-hardware-requirem…

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,7 @@ exclude_patterns = [
     "**/eggs",
     "_inc/.*",
     "plone.restapi/.*",
+    "plone.restapi/*.md",
     "plone.restapi/bin",
     "plone.restapi/develop-eggs",
     "plone.restapi/docs/source/glossary.md",  # There can be only one Glossary.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ linkcheck_ignore = [
     r"https://coveralls.io/repos/github/plone/plone.restapi/badge.svg\?branch=main",  # plone.restapi
     r"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors#Identifying_the_issue",  # volto
     r"https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-version-10-0",  # volto
-    r"https://browsersl.ist/#",
+    r"https://browsersl.ist/#",  # volto
     # Ignore unreliable sites
     r"https://web.archive.org/",
     r"https://www.gnu.org/",  # Consider removal when upgrading Sphinx

--- a/docs/contributing/documentation/admins.md
+++ b/docs/contributing/documentation/admins.md
@@ -103,7 +103,7 @@ The following are example files that you can use to configure your project for p
 
 -   [Plone Sphinx Theme `Makefile`](https://github.com/plone/plone-sphinx-theme/blob/main/Makefile), specifically the `rtd-pr-preview` section.
     This is the command to use to build documentation previews on Read the Docs.
--   [Plone Sphinx Theme `requirements-docs.txt`](https://github.com/plone/plone-sphinx-theme/blob/main/requirements-docs.txt) specifies the requirements to use Plone Sphinx Theme and build the docs.
+-   [Plone Sphinx Theme `pyproject.toml`](https://github.com/plone/plone-sphinx-theme/blob/main/pyproject.toml) specifies the requirements to use Plone Sphinx Theme and build the docs.
 -   [Plone Sphinx Theme `conf.py`](https://github.com/plone/plone-sphinx-theme/blob/main/docs/conf.py) the Sphinx configuration file to build the docs.
 -   [Plone Sphinx Theme `.readthedocs.yaml`](https://github.com/plone/plone-sphinx-theme/blob/main/.readthedocs.yaml) specifies the configuration and Makefile command that Read the Docs uses to build the docs.
 -   [Plone Sphinx Theme `.github/workflows/rtd-pr-preview.yml`](https://github.com/plone/plone-sphinx-theme/blob/main/.github/workflows/rtd-pr-preview.yml) specifies when to build the docs, specifically only when a pull request is opened and there are changes to the documentation files.

--- a/docs/contributing/documentation/index.md
+++ b/docs/contributing/documentation/index.md
@@ -175,7 +175,7 @@ git push
 ```
 
 ```{seealso}
-[How to undo a committed submodule command](https://stackoverflow.com/a/46500544/2214933).
+[How to undo a committed submodule command](https://stackoverflow.com/questions/46500441/how-to-undo-a-committed-submodule-command/46500544#46500544).
 ```
 
 

--- a/docs/deployment/server-environment.md
+++ b/docs/deployment/server-environment.md
@@ -15,7 +15,7 @@ This page in the deployment guide covers how to prepare a server environment for
 You will need to prepare your environment with the following items.
 
 ```{note}
-Should we reuse or update {ref}`install-packages-hardware-requirements-label`?
+Should we reuse or update {ref}`create-project-cookieplone-hardware-requirements-label`?
 ```
 
 -   server instance with an operating system that Plone can run on

--- a/docs/install/containers/images/backend.md
+++ b/docs/install/containers/images/backend.md
@@ -222,7 +222,7 @@ services:
 | `CORS_ALLOW_HEADERS` | A comma separated list of request headers allowed to be sent by the client, for example `X-My-Header` | `Accept,Authorization,Content-Type,X-Custom-Header` |
 | `CORS_MAX_AGE` | Indicates how long the results of a preflight request can be cached | `3600` |
 
-These variables are used to configure [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+These variables are used to configure [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS).
 
 (containers-images-backend-add-ons-label)=
 

--- a/docs/install/containers/index.md
+++ b/docs/install/containers/index.md
@@ -55,7 +55,7 @@ The system requirements include those required by Docker itself.
 -   [Windows](https://docs.docker.com/desktop/setup/install/windows-install/)
 
 Plone 6 itself requires memory and disk space in addition to those of Docker alone.
-See its {ref}`install-packages-hardware-requirements-label`.
+See its {ref}`create-project-cookieplone-hardware-requirements-label`.
 
 
 ### Install Docker


### PR DESCRIPTION
…ents-label`

- Ignore plone.restapi meta *.md files
- Fix redirects and 404s

Don't merge until https://github.com/plone/volto/pull/6835 is merged, and the submodule tip is updated.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1911.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->