### PR TITLE
Define SUPPORTED_PYTHON_VERSIONS_PLONE62.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -321,6 +321,7 @@ myst_substitutions = {
     "fawrench": '<span class="fa fa-wrench" style="font-size: 1.6em;"></span>',
     "SUPPORTED_PYTHON_VERSIONS_PLONE60": "3.9, 3.10, 3.11, 3.12, or 3.13",
     "SUPPORTED_PYTHON_VERSIONS_PLONE61": "3.10, 3.11, 3.12, or 3.13",
+    "SUPPORTED_PYTHON_VERSIONS_PLONE62": "3.10, 3.11, 3.12, or 3.13",
 }
 
 


### PR DESCRIPTION
It is not used yet, just like `SUPPORTED_PYTHON_VERSIONS_PLONE60` is not used anymore, but let's be prepared. In `buildout.coredev` in branch `release/6.2-dev` I [started pointing to it](https://github.com/plone/buildout.coredev/commit/e04617731786514ce8e10833d3fc7e41200abc5b).

Steve, I have updated the text in my release checklists for 6.1 and 6.0 as well, as you indicated.  Thanks.
