### PR TITLE
Update create-a-distribution.md

### DIFF
--- a/docs/developer-guide/create-a-distribution.md
+++ b/docs/developer-guide/create-a-distribution.md
@@ -295,8 +295,8 @@ Then add it to your {file}`dependencies.zcml` file.
   <!-- List all packages your distribution depends on here -->
   <include package="plone.volto" />
   <include package="plone.restapi" />
-  <include package="collective.person" />
   <include package="plone.distribution" />
+  <include package="collective.person" />
 
 </configure>
 ```


### PR DESCRIPTION
## Description

The line highlighted was wrong, but it probably makes more sense to move the line that needs highlight, as should first load the `plone.distribution` ZCML rather than the `collective.person`.

See the current status, notice that on the second code snippet `plone.distribution` is highlighted, rather than `collective.person`.

![imatge](https://github.com/user-attachments/assets/3b441e44-ac6a-4cc3-84fa-e04bc0253aa7)


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1915.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->