### PR TITLE
Remove the external link icon for internal links in submodules

### DIFF
--- a/docs/_static/documentation.css
+++ b/docs/_static/documentation.css
@@ -1,0 +1,17 @@
+/*
+  Remove the external link icon from Plone Sphinx Theme for links
+  in submodules that refer to Plone 6 Documentation via Intersphinx.
+  Although these links have `external` in their class, they are
+  actually internal to Plone 6 Documentation.
+*/
+.reference.external::after {
+  all: unset;
+}
+a:not([title="(in Plone Documentation v6)"]).reference.external::after {
+  margin-left: .3em;
+  display: inline-block;
+  content: var(--pst-icon-external-link);
+  white-space: nowrap;
+  font: var(--fa-font-solid);
+  font-size: .75em;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,7 +273,7 @@ html_title = "%(project)s v%(release)s" % {"project": project, "release": releas
 # If false, no index is generated.
 html_use_index = True
 
-html_css_files = [("print.css", {"media": "print"})]
+html_css_files = ["documentation.css", ("print.css", {"media": "print"})]
 html_js_files = []
 
 html_extra_path = [


### PR DESCRIPTION
Remove the external link icon from Plone Sphinx Theme for links in submodules that refer to Plone 6 Documentation via Intersphinx.

Although these links have `external` in their class, they are actually internal to Plone 6 Documentation.

For example, see the index page of Volto UI.

https://6.docs.plone.org/volto/

And see that the external link icon for "Plone content management system" is correct, but the link for "First-time contributors" is actually internal but has the external link icon.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1916.org.readthedocs.build/volto/

<!-- readthedocs-preview plone6 end -->