### PR TITLE
Add a link from the Developer Guide to Develop Volto add-ons

### DIFF
--- a/docs/admin-guide/index.md
+++ b/docs/admin-guide/index.md
@@ -37,10 +37,6 @@ override-core
 backup-restore-plone-buildout
 /upgrade/index
 ```
-% TODO: uncomment and add the following link to the Operate toctree when https://github.com/plone/volto/pull/6397 is merged.
-% https://volto--6397.org.readthedocs.build/development/add-ons/install-an-add-on.html
-% /volto/development/add-ons/index
-
 
 ```{toctree}
 :maxdepth: 1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -386,15 +386,16 @@ redirects = {
     "contributing/plone-api": "/plone.api/contribute.html",
     "contributing/plone-restapi": "/plone.restapi/docs/source/contributing/index.html",
     "contributing/volto": "/volto/contributing/index.html",
+    "developer-guide/develop-volto-add-ons-index": "/volto/development/add-ons/index.html",
+    "install/create-project": "/install/create-project-cookieplone.html",
     "install/install-from-packages": "/install/create-project.html",
     "manage/frontend": "/volto/addons/index.html",
-    "install/create-project": "/install/create-project-cookieplone.html",
-    "user-guide/editor": "/volto/user-manual/index.html",
-    "reference-guide/volto-configuration-settings.html": "/volto/configuration/settings-reference.html",
-    "reference-guide/volto-javascript-client.html": "/volto/client/index.html",
+    "reference-guide/plone.api-methods.html": "/plone.api/api/index.html",
     "reference-guide/plone.restapi-usage.html": "/plone.restapi/docs/source/usage/index.html",
     "reference-guide/plone.restapi-endpoints.html": "/plone.restapi/docs/source/endpoints/index.html",
-    "reference-guide/plone.api-methods.html": "/plone.api/api/index.html",
+    "reference-guide/volto-configuration-settings.html": "/volto/configuration/settings-reference.html",
+    "reference-guide/volto-javascript-client.html": "/volto/client/index.html",
+    "user-guide/editor": "/volto/user-manual/index.html",
 }
 
 

--- a/docs/developer-guide/develop-volto-add-ons-index.md
+++ b/docs/developer-guide/develop-volto-add-ons-index.md
@@ -1,0 +1,12 @@
+---
+myst:
+  html_meta:
+    "description": "How to develop Volto add-ons"
+    "property=og:description": "How to develop Volto add-ons"
+    "property=og:title": "Develop Volto add-ons"
+    "keywords": "Plone, Volto, add-ons, development"
+---
+
+# Develop Volto add-ons
+
+See {doc}`/volto/development/add-ons/index` under {guilabel}`Volto UI > Development > Develop Volto add-ons`.

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -21,6 +21,7 @@ You can help consolidate all of development documentation here, even if it is to
 ```{toctree}
 :maxdepth: 2
 
+develop-volto-add-ons-index
 create-a-distribution
 standardize-python-project-configuration
 ```


### PR DESCRIPTION
- add Sphinx reredirect for link

@sneridagh we overlooked this in https://github.com/plone/volto/pull/6397

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: 

- https://plone6--1945.org.readthedocs.build/developer-guide/index.html
- https://plone6--1945.org.readthedocs.build/developer-guide/develop-volto-add-ons-index.md should redirect to https://plone6--1945.org.readthedocs.build/volto/development/add-ons/index.html

<!-- readthedocs-preview plone6 end -->