### PR TITLE
Documentation and example for `pattern_options` multiadapter

### DIFF
--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -474,7 +474,7 @@ self.widgets["ds_pregu_pers"].disabled = "disabled"
 
 ### Customize existing widgets `pattern_options`
 
-There is a special attribute called `pattern_options` which is used in Classic-UI for pattern configuration and in Volto (how ?).
+There is a special attribute called `pattern_options` which is used in Classic UI for pattern configuration and in Volto (how ?).
 
 If you define your own schema you can set this attribute with autoform directives (see {ref}`relations-configure-the-relateditemsfieldwidget-label` for example).
 

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -474,7 +474,7 @@ self.widgets["ds_pregu_pers"].disabled = "disabled"
 
 ### Customize existing widgets `pattern_options`
 
-There is a special attribute called `pattern_options` which is used in Classic UI for pattern configuration and in Volto (how ?).
+There is a special attribute called `pattern_options` which is primarily used in Classic UI for pattern configuration.
 
 If you define your own schema, you can set this attribute with autoform directives.
 See {ref}`relations-configure-the-relateditemsfieldwidget-label` for an example.

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -482,10 +482,17 @@ See {ref}`relations-configure-the-relateditemsfieldwidget-label` for an example.
 To customize or extend `pattern_options` for existing schema widgets, you can create a `z3c.form.interface.IValue` multiadapter as shown.
 
 ```{code-block} python
-from z3c.form.interface import IValue
+from z3c.form.interfaces import IForm
+from z3c.form.interfaces import IValue
+from z3c.form.interfaces import IWidget
+from zope.component impport adapter
 from zope.interface import implementer
+from zope.interface import Interface
+from zope.publisher.interfaces import  IRequest
+from zope.schema.interfaces import IField
 
 @implementer(IValue)
+@adapter(Interface, IRequest, IForm, IField, IWidget)
 class CustomPatternOptions:
 
     def __init__(self, context, request, form, field, widget):
@@ -506,7 +513,6 @@ Now register the adapter with ZCML as shown.
 
 ```xml
 <adapter factory=".CustomPatternOptions"
-         for="* * * * *"
          name="pattern_options">
 ```
 

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -472,6 +472,52 @@ self.widgets["ds_pregu_pers"].disabled = "disabled"
 ```
 
 
+### Customize existing widgets `pattern_options`
+
+There is a special attribute called `pattern_options` which is used in Classic-UI for pattern configuration and in Volto (how ?).
+
+If you define your own schema you can set this attribute with autoform directives (see {ref}`relations-configure-the-relateditemsfieldwidget-label` for example).
+
+To customize or extend `pattern_options` for existing schema widgets you can create a `z3c.form.interface.IValue` multiadapter:
+
+```{code-block} python
+:linenos:
+
+    from z3c.form.interface import IValue
+    from zope.interface import implementer
+
+    @implementer(IValue)
+    class CustomPatternOptions:
+
+        def __init__(self, context, request, form, field, widget):
+            self.context = context
+            self.request = request
+            self.form = form
+            self.field = field
+            self.widget = widget
+
+        def get(self):
+            # return a dictionary with your custom options
+            return {
+                "myoption": "value",
+            }
+```
+
+Now register the adapter with zcml:
+
+```xml
+<adapter factory=".CustomPatternOptions"
+         for="* * * * *"
+         name="pattern_options">
+```
+
+This registers the `pattern_options` for every field in every widget.
+
+You can define the adapter more explicit by providing the fields and/or widgets interface in the `for` attribute.
+
+See an example here {ref}`classic-ui-recipes-customize-pattern-options`.
+
+
 ## Set widget templates
 
 You might want to customize the template of a widget with custom HTML code.

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -509,17 +509,17 @@ class CustomPatternOptions:
         }
 ```
 
-Now register the adapter with ZCML as shown.
+This defines an adapter for every field widget in every form.
+
+You can define the adapter more explicitly by providing different interfaces.
+See an example in {ref}`classic-ui-recipes-customize-pattern-options`.
+
+Now register the `pattern_options` named adapter with ZCML as shown.
 
 ```xml
 <adapter factory=".CustomPatternOptions"
          name="pattern_options">
 ```
-
-This registers the `pattern_options` for every field in every widget.
-
-You can define the adapter more explicitly by providing the fields or widgets interface in the `for` attribute.
-See an example in {ref}`classic-ui-recipes-customize-pattern-options`.
 
 
 ## Set widget templates

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -476,7 +476,8 @@ self.widgets["ds_pregu_pers"].disabled = "disabled"
 
 There is a special attribute called `pattern_options` which is used in Classic UI for pattern configuration and in Volto (how ?).
 
-If you define your own schema you can set this attribute with autoform directives (see {ref}`relations-configure-the-relateditemsfieldwidget-label` for example).
+If you define your own schema, you can set this attribute with autoform directives.
+See {ref}`relations-configure-the-relateditemsfieldwidget-label` for an example.
 
 To customize or extend `pattern_options` for existing schema widgets you can create a `z3c.form.interface.IValue` multiadapter:
 

--- a/docs/backend/widgets.md
+++ b/docs/backend/widgets.md
@@ -479,32 +479,30 @@ There is a special attribute called `pattern_options` which is used in Classic U
 If you define your own schema, you can set this attribute with autoform directives.
 See {ref}`relations-configure-the-relateditemsfieldwidget-label` for an example.
 
-To customize or extend `pattern_options` for existing schema widgets you can create a `z3c.form.interface.IValue` multiadapter:
+To customize or extend `pattern_options` for existing schema widgets, you can create a `z3c.form.interface.IValue` multiadapter as shown.
 
 ```{code-block} python
-:linenos:
+from z3c.form.interface import IValue
+from zope.interface import implementer
 
-    from z3c.form.interface import IValue
-    from zope.interface import implementer
+@implementer(IValue)
+class CustomPatternOptions:
 
-    @implementer(IValue)
-    class CustomPatternOptions:
+    def __init__(self, context, request, form, field, widget):
+        self.context = context
+        self.request = request
+        self.form = form
+        self.field = field
+        self.widget = widget
 
-        def __init__(self, context, request, form, field, widget):
-            self.context = context
-            self.request = request
-            self.form = form
-            self.field = field
-            self.widget = widget
-
-        def get(self):
-            # return a dictionary with your custom options
-            return {
-                "myoption": "value",
-            }
+    def get(self):
+        # return a dictionary with your custom options
+        return {
+            "myoption": "value",
+        }
 ```
 
-Now register the adapter with zcml:
+Now register the adapter with ZCML as shown.
 
 ```xml
 <adapter factory=".CustomPatternOptions"
@@ -514,9 +512,8 @@ Now register the adapter with zcml:
 
 This registers the `pattern_options` for every field in every widget.
 
-You can define the adapter more explicit by providing the fields and/or widgets interface in the `for` attribute.
-
-See an example here {ref}`classic-ui-recipes-customize-pattern-options`.
+You can define the adapter more explicitly by providing the fields or widgets interface in the `for` attribute.
+See an example in {ref}`classic-ui-recipes-customize-pattern-options`.
 
 
 ## Set widget templates

--- a/docs/classic-ui/recipes.md
+++ b/docs/classic-ui/recipes.md
@@ -58,11 +58,17 @@ First create a multiadapter as shown.
 ```{code-block} python
 
 from plone import api
-from z3c.form.interface import IValue
+from plone.app.z3cform.interfaces import IContentBrowserWidget
+from plone.dexterity.interfaces import IDexterityContent
+from z3c.form.interfaces import IForm
+from z3c.form.interfaces import IValue
+from zope.component impport adapter
 from zope.interface import implementer
-
+from zope.publisher.interfaces import  IRequest
+from zope.schema.interfaces import IField
 
 @implementer(IValue)
+@adapter(IDexterityContent, IRequest, IForm, IField, IContentBrowserWidget)
 class ContentbrowserPatternOptions:
 
     def __init__(self, context, request, form, field, widget):
@@ -86,10 +92,5 @@ Then register it with ZCML as shown.
 
 ```xml
 <adapter factory=".ContentbrowserPatternOptions"
-         for="*
-              *
-              *
-              *
-              plone.app.z3cform.interfaces.IContentBrowserWidget"
          name="pattern_options">
 ```

--- a/docs/classic-ui/recipes.md
+++ b/docs/classic-ui/recipes.md
@@ -51,39 +51,38 @@ Then register the adapter in ZCML.
 
 ## Customize `pattern_options`
 
-This example shows how to customize the {menuselection}`Favorites` menu in the contentbrowser pattern:
+The following example shows how to customize the {menuselection}`Favorites` menu in the `contentbrowser` pattern.
 
-First create a multiadapter:
+First create a multiadapter as shown.
 
 ```{code-block} python
-:linenos:
 
-    from plone import api
-    from z3c.form.interface import IValue
-    from zope.interface import implementer
+from plone import api
+from z3c.form.interface import IValue
+from zope.interface import implementer
 
 
-    @implementer(IValue)
-    class ContentbrowserPatternOptions:
+@implementer(IValue)
+class ContentbrowserPatternOptions:
 
-        def __init__(self, context, request, form, field, widget):
-            self.context = context
-            self.request = request
-            self.form = form
-            self.field = field
-            self.widget = widget
+    def __init__(self, context, request, form, field, widget):
+        self.context = context
+        self.request = request
+        self.form = form
+        self.field = field
+        self.widget = widget
 
-        def get(self):
-            portal_path = "/".join(api.portal.get().getPhysicalPath())
-            return {
-                "favorites": [
-                    {"title": "my favorite folder", "path": f"{portal_path}/path/to/my/favorite/folder"},
-                    {"title": "Portal", "path": portal_path},
-                ],
-            }
+    def get(self):
+        portal_path = "/".join(api.portal.get().getPhysicalPath())
+        return {
+            "favorites": [
+                {"title": "my favorite folder", "path": f"{portal_path}/path/to/my/favorite/folder"},
+                {"title": "Portal", "path": portal_path},
+            ],
+        }
 ```
 
-And register it with zcml:
+Then register it with ZCML as shown.
 
 ```xml
 <adapter factory=".ContentbrowserPatternOptions"

--- a/docs/classic-ui/recipes.md
+++ b/docs/classic-ui/recipes.md
@@ -46,3 +46,51 @@ Then register the adapter in ZCML.
     name="myproject-customclasses"
 />
 ```
+
+(classic-ui-recipes-customize-pattern-options)=
+
+## Customize `pattern_options`
+
+This example shows how to customize the {menuselection}`Favorites` menu in the contentbrowser pattern:
+
+First create a multiadapter:
+
+```{code-block} python
+:linenos:
+
+    from plone import api
+    from z3c.form.interface import IValue
+    from zope.interface import implementer
+
+
+    @implementer(IValue)
+    class ContentbrowserPatternOptions:
+
+        def __init__(self, context, request, form, field, widget):
+            self.context = context
+            self.request = request
+            self.form = form
+            self.field = field
+            self.widget = widget
+
+        def get(self):
+            portal_path = "/".join(api.portal.get().getPhysicalPath())
+            return {
+                "favorites": [
+                    {"title": "my favorite folder", "path": f"{portal_path}/path/to/my/favorite/folder"},
+                    {"title": "Portal", "path": portal_path},
+                ],
+            }
+```
+
+And register it with zcml:
+
+```xml
+<adapter factory=".ContentbrowserPatternOptions"
+         for="*
+              *
+              *
+              *
+              plone.app.z3cform.interfaces.IContentBrowserWidget"
+         name="pattern_options">
+```


### PR DESCRIPTION
This is for customizing `pattern_options` mainly used for configuring patterns in Classic-UI ...  but I saw, that the options is also used in Volto ... maybe someone can explain that in the first sentence?


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1948.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->