### PR TITLE
doc the weblate workflow for Volto

### DIFF
--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -112,6 +112,19 @@ When you save a translation, then it is committed on a branch used only for tran
 Maintainers will periodically review the pull request that Weblate creates automatically, and merge it.
 
 
+### Wewblate workflow in Volto
+
+Volto does some checks in all pull-requests that require a changelog entry to be present and the po files to have a given formatting.
+
+Weblate doesn't create such changelog entry and its po style guide does not match the one of Volto, so to merge the changes coming to weblate, a maintainer has to do the following:
+
+- Clone the `translations-18.x.x` branch from the Volto repository
+- Add a changelog file in the `news` folder with the relevant entry
+- Run `make i18n` to reformat the po files.
+- Push back the changes to GitHub and wait to the CI checks to success.
+- Merge the pull request when the checks are green.
+
+
 (contributing-plone-core-translations-support-label)=
 
 ## Support

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -116,7 +116,8 @@ Maintainers will periodically review the pull request that Weblate creates autom
 
 For all pull requests, Volto's CI checks for both the presence of a change log entry and that the `.po` files used in translations comply with a standard format.
 
-Weblate doesn't create such changelog entry and its po style guide does not match the one of Volto, so to merge the changes coming to weblate, a maintainer has to do the following:
+Weblate doesn't create a change log entry, and its `.po` file style guide does not match Volto's.
+This means that a maintainer has to perform the following tasks to merge the changes coming from Weblate.
 
 - Checkout the `translations-18.x.x` branch from the Volto repository.
 - Add a change log file in the `packages/volto/news` folder.

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -118,11 +118,11 @@ For all pull requests, Volto's CI checks for both the presence of a change log e
 
 Weblate doesn't create such changelog entry and its po style guide does not match the one of Volto, so to merge the changes coming to weblate, a maintainer has to do the following:
 
-- Clone the `translations-18.x.x` branch from the Volto repository
-- Add a changelog file in the `news` folder with the relevant entry
-- Run `make i18n` to reformat the po files.
-- Push back the changes to GitHub and wait to the CI checks to success.
-- Merge the pull request when the checks are green.
+- Checkout the `translations-18.x.x` branch from the Volto repository.
+- Add a change log file in the `packages/volto/news` folder.
+- Run `make i18n` to reformat the `.po` files.
+- Commit and push the changes to GitHub.
+- When all CI checks succeed, then merge the pull request.
 
 
 (contributing-plone-core-translations-support-label)=

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -117,7 +117,7 @@ Maintainers will periodically review the pull request that Weblate creates autom
 For all pull requests, Volto's CI checks for both the presence of a change log entry and that the `.po` files used in translations comply with a standard format.
 
 Weblate doesn't create a change log entry, and its `.po` file style guide does not match Volto's.
-This means that a maintainer has to perform the following tasks to merge the changes coming from Weblate.
+This means that a Volto Team member has to perform the following tasks to merge the changes coming from Weblate.
 
 - Checkout the `translations-18.x.x` branch from the Volto repository.
 - Add a change log file in the `packages/volto/news` folder.

--- a/docs/i18n-l10n/contributing-translations.md
+++ b/docs/i18n-l10n/contributing-translations.md
@@ -114,7 +114,7 @@ Maintainers will periodically review the pull request that Weblate creates autom
 
 ### Wewblate workflow in Volto
 
-Volto does some checks in all pull-requests that require a changelog entry to be present and the po files to have a given formatting.
+For all pull requests, Volto's CI checks for both the presence of a change log entry and that the `.po` files used in translations comply with a standard format.
 
 Weblate doesn't create such changelog entry and its po style guide does not match the one of Volto, so to merge the changes coming to weblate, a maintainer has to do the following:
 


### PR DESCRIPTION
As noted in https://github.com/plone/volto/pull/7135#issuecomment-2919778585 during the Beethoven Sprint 2025 we (@fredvd  and me) could fix the PCA checks but now we need to document the procedure of how to handle those pull requests, because we need to do some manual work (to add the changelog entry and reformat the po files), before merging and make CI happy.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1957.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->