### PR TITLE
Improve the rst2myst conversion documentation.

### DIFF
--- a/docs/contributing/documentation/admins.md
+++ b/docs/contributing/documentation/admins.md
@@ -40,15 +40,18 @@ We did this for `plone.app.dexterity` and several other projects.
 1.  Delete any non-documentation files from the clone.
 1.  Move the documentation files and subfolders to the root of the clone, retaining the documentation structure.
 1.  Convert the reStructuredText documentation files to MyST.
-    The example commands below assume that there are files at the root of the clone and in one sub-level of nested directories.
-    For deeper nesting, insert globbing syntax for each sub-level as `**/`
+    The example commands below assume that there are files at the root of the clone and in one sublevel of nested directories.
+    For deeper nesting, insert globbing syntax for each sublevel as `**/`.
 
     ```shell
-    bin/rst2myst convert -R project/*.rst
-    bin/rst2myst convert -R project/**/*.rst
+    bin/rst2myst convert project/*.rst
+    bin/rst2myst convert project/**/*.rst
+    ```
+    ```{seealso}
+    [Command line options for `rst2myst`](https://rst-to-myst.readthedocs.io/en/latest/cli.html)
     ```
 
-1.  Add HTML meta data to the converted files.
+1.  Add HTML metadata to the converted files.
 
     ```shell
     cd project

--- a/docs/contributing/documentation/myst-reference.md
+++ b/docs/contributing/documentation/myst-reference.md
@@ -298,7 +298,7 @@ For an in depth discussion of privacy issues, see [How to embed YouTube videos w
 
 -   PeerTube's [Privacy guide](https://docs.joinpeertube.org/admin/privacy-guide) helps administrators comply with terms of government policies.
 -   YouTube's [Manage video embedding options, Turn on privacy-enhanced mode](https://support.google.com/youtube/answer/171780)
--   Vimeo's [supported player parameters](https://help.vimeo.com/hc/en-us/articles/12426260232977-About-Player-parameters#h_01FNYA7F7GKWE17XDQJPMBC058)
+-   Vimeo's [supported player parameters](https://help.vimeo.com/hc/en-us/articles/12426260232977-About-Player-Parameters)
 ```
 
 ```{seealso}


### PR DESCRIPTION
- Remove the `-R` option from the example commands
- Add link to CLI reference documentation
- Spelling and grammar fixes

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1958.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->