### PR TITLE
update docker examples for Varnish3, remove obsolete 'version' yaml

### DIFF
--- a/docs/install/containers/examples/nginx-plone.md
+++ b/docs/install/containers/examples/nginx-plone.md
@@ -69,7 +69,6 @@ You can either use `plone.localhost`, or add it in your `/etc/hosts` file or DNS
 Now let's create a `docker-compose.yml` file:
 
 ```yaml
-version: "3"
 services:
 
   webserver:

--- a/docs/install/containers/examples/nginx-volto-plone-postgresql.md
+++ b/docs/install/containers/examples/nginx-volto-plone-postgresql.md
@@ -83,7 +83,6 @@ You can either use `localhost`, or add it in your `/etc/hosts` file or DNS to po
 Now let's create a `docker-compose.yml` file:
 
 ```yaml
-version: "3"
 services:
 
   webserver:

--- a/docs/install/containers/examples/nginx-volto-plone-zeo.md
+++ b/docs/install/containers/examples/nginx-volto-plone-zeo.md
@@ -83,7 +83,6 @@ You can either use `localhost`, or add it in your `/etc/hosts` file or DNS to po
 Now let's create a `docker-compose.yml` file:
 
 ```yaml
-version: "3"
 services:
 
   webserver:
@@ -110,6 +109,9 @@ services:
     environment:
       SITE: Plone
       ZEO_ADDRESS: db:8100
+      ZEO_SHARED_BLOB_DIR: on   #otherwise the backend will create its own filestorage/blogstorage
+    volumes:
+      - data:/data              #the backend and db need access to the same volume
     ports:
     - "8080:8080"
     depends_on:

--- a/docs/install/containers/examples/nginx-volto-plone-zeo.md
+++ b/docs/install/containers/examples/nginx-volto-plone-zeo.md
@@ -109,7 +109,7 @@ services:
     environment:
       SITE: Plone
       ZEO_ADDRESS: db:8100
-      ZEO_SHARED_BLOB_DIR: on   #otherwise the backend will create its own filestorage/blogstorage
+      ZEO_SHARED_BLOB_DIR: on   # otherwise the backend will create its own blob storage
     volumes:
       - data:/data              #the backend and db need access to the same volume
     ports:

--- a/docs/install/containers/examples/nginx-volto-plone-zeo.md
+++ b/docs/install/containers/examples/nginx-volto-plone-zeo.md
@@ -111,7 +111,7 @@ services:
       ZEO_ADDRESS: db:8100
       ZEO_SHARED_BLOB_DIR: on   # otherwise the backend will create its own blob storage
     volumes:
-      - data:/data              #the backend and db need access to the same volume
+      - data:/data              # the backend and database need access to the same volume
     ports:
     - "8080:8080"
     depends_on:

--- a/docs/install/containers/examples/nginx-volto-plone.md
+++ b/docs/install/containers/examples/nginx-volto-plone.md
@@ -81,7 +81,6 @@ You can either use `localhost`, or add it in your `/etc/hosts` file or DNS to po
 Now let's create a `docker-compose.yml` file:
 
 ```yaml
-version: "3"
 services:
 
   webserver:

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     "description": "Basic Plone 6 setup with only one backend, a ZEO server, and data being persisted in a Docker volume."
-    "property=og:description": "Basic Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
+    "property=og:description": "Basic Plone 6 setup with only one backend, a ZEO server, and data being persisted in a Docker volume."
     "property=og:title": "Traefik Proxy, Frontend, Backend, Varnish container example"
     "keywords": "Plone 6, Container, Docker, Traefik Proxy, Frontend, Backend, Varnish"
 ---

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -397,7 +397,7 @@ services:
       ZEO_ADDRESS: db:8100
       ZEO_SHARED_BLOB_DIR: on  # otherwise the backend will create its own blob storage
     volumes:
-      - data:/data              #the backend and db need access to the same volume
+      - data:/data              # the backend and database need access to the same volume
     ports:
       - 8080:8080
     depends_on:

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -404,7 +404,7 @@ services:
       - db
 #   If the Docker container is run with a UID other than the UID which owns the local file system persistent storage,
 #   explicitly make the container run with the correct UID. For example, `user: 1000:1000`.
-#   In that case make sure also the 'db' service gets the same 'user: 1000:1000' configuration,
+#   In that case, also make sure that the `db` service gets the same `user: 1000:1000` configuration,
 #   as they both need access to the filesystem
 
 

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -405,7 +405,7 @@ services:
 #   If the Docker container is run with a UID other than the UID which owns the local file system persistent storage,
 #   explicitly make the container run with the correct UID. For example, `user: 1000:1000`.
 #   In that case, also make sure that the `db` service gets the same `user: 1000:1000` configuration,
-#   as they both need access to the filesystem
+#   as they both need access to the file system.
 
 
     labels:

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -395,7 +395,7 @@ services:
       PROFILES: "plone.app.caching:with-caching-proxy"
     environment:
       ZEO_ADDRESS: db:8100
-      ZEO_SHARED_BLOB_DIR: on #otherwise the backend will create its own filestorage/blogstorage
+      ZEO_SHARED_BLOB_DIR: on  # otherwise the backend will create its own blob storage
     volumes:
       - data:/data              #the backend and db need access to the same volume
     ports:

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -1,15 +1,15 @@
 ---
 myst:
   html_meta:
-    "description": "Very simple Plone 6 setup with only one backend and data being persisted in a Docker volume."
-    "property=og:description": "Very simple Plone 6 setup with only one backend and data being persisted in a Docker volume."
+    "description": "Simple Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
+    "property=og:description": "Simple Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
     "property=og:title": "Traefik Proxy, Frontend, Backend, Varnish container example"
     "keywords": "Plone 6, Container, Docker, Traefik Proxy, Frontend, Backend, Varnish"
 ---
 
-# Traefik Proxy, Frontend, Backend, Varnish container example
+# Traefik Proxy, Frontend, Backend, ZEO, Varnish container example
 
-This example is a very simple setup with one backend and data being persisted in a Docker volume.
+This example is a simple setup with one backend accessing a ZEO server and data being persisted in a Docker volume.
 
 {term}`Traefik Proxy` in this example is used as a reverse proxy.
 
@@ -323,7 +323,6 @@ You can either use `localhost`, or add it in your `/etc/hosts` file or DNS to po
 Now let's create a {file}`docker-compose.yml` file:
 
 ```yaml
-version: "3"
 services:
   webserver:
     image: traefik
@@ -381,7 +380,7 @@ services:
       - traefik.http.routers.rt-frontend-public.service=svc-varnish
       - traefik.http.routers.rt-frontend-public.middlewares=gzip
       # Router: Internal
-      - traefik.http.routers.rt-frontend-internal.rule=Host(`plone.localhost`) && Headers(`X-Varnish-Routed`, `1`)
+      - traefik.http.routers.rt-frontend-internal.rule=Host(`plone.localhost`) && Header(`X-Varnish-Routed`, `1`)
       - traefik.http.routers.rt-frontend-internal.entrypoints=http
       - traefik.http.routers.rt-frontend-internal.service=svc-frontend
     depends_on:
@@ -394,6 +393,21 @@ services:
     environment:
       SITE: Plone
       PROFILES: "plone.app.caching:with-caching-proxy"
+    environment:
+      ZEO_ADDRESS: db:8100
+      ZEO_SHARED_BLOB_DIR: on #otherwise the backend will create its own filestorage/blogstorage
+    volumes:
+      - data:/data              #the backend and db need access to the same volume
+    ports:
+      - 8080:8080
+    depends_on:
+      - db
+#   If the docker container is run with another uid than the uid owning the local filesystem persistent storage,
+#   explicitly make the container run with the correct uid, for example  user: 1000:1000
+#   In that case make sure also the 'db' service gets the same 'user: 1000:1000' configuration,
+#   as they both need access to the filesystem
+
+
     labels:
       - traefik.enable=true
       - traefik.constraint-label=public
@@ -414,12 +428,12 @@ services:
       - traefik.http.routers.rt-backend-api-public.middlewares=gzip
       # Router: Internal
       ## /++api++/
-      - traefik.http.routers.rt-backend-api-internal.rule=Host(`plone.localhost`) && PathPrefix(`/++api++`) && Headers(`X-Varnish-Routed`, `1`)
+      - traefik.http.routers.rt-backend-api-internal.rule=Host(`plone.localhost`) && PathPrefix(`/++api++`) && Header(`X-Varnish-Routed`, `1`)
       - traefik.http.routers.rt-backend-api-internal.entrypoints=http
       - traefik.http.routers.rt-backend-api-internal.service=svc-backend
       - traefik.http.routers.rt-backend-api-internal.middlewares=gzip,mw-backend-vhm-api
       ## /ClassicUI/
-      - traefik.http.routers.rt-backend-ui-internal.rule=Host(`plone.localhost`) && PathPrefix(`/ClassicUI`) && Headers(`X-Varnish-Routed`, `1`)
+      - traefik.http.routers.rt-backend-ui-internal.rule=Host(`plone.localhost`) && PathPrefix(`/ClassicUI`) && Header(`X-Varnish-Routed`, `1`)
       - traefik.http.routers.rt-backend-ui-internal.entrypoints=http
       - traefik.http.routers.rt-backend-ui-internal.service=svc-backend
       - traefik.http.routers.rt-backend-ui-internal.middlewares=gzip,mw-backend-vhm-ui
@@ -452,6 +466,16 @@ services:
       - "8000-8001:80"
     depends_on:
       - backend
+
+  db:
+    image: plone/plone-zeo:latest
+    volumes:
+      - data:/data
+    ports:
+    - "8100:8100"
+
+volumes:
+  data: {}
 ```
 
 

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -403,7 +403,7 @@ services:
     depends_on:
       - db
 #   If the Docker container is run with a UID other than the UID which owns the local file system persistent storage,
-#   explicitly make the container run with the correct uid, for example  user: 1000:1000
+#   explicitly make the container run with the correct UID. For example, `user: 1000:1000`.
 #   In that case make sure also the 'db' service gets the same 'user: 1000:1000' configuration,
 #   as they both need access to the filesystem
 

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    "description": "Basic Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
+    "description": "Basic Plone 6 setup with only one backend, a ZEO server, and data being persisted in a Docker volume."
     "property=og:description": "Basic Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
     "property=og:title": "Traefik Proxy, Frontend, Backend, Varnish container example"
     "keywords": "Plone 6, Container, Docker, Traefik Proxy, Frontend, Backend, Varnish"

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -1,15 +1,15 @@
 ---
 myst:
   html_meta:
-    "description": "Simple Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
-    "property=og:description": "Simple Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
+    "description": "Basic Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
+    "property=og:description": "Basic Plone 6 setup with only one backend, a ZEO server and data being persisted in a Docker volume."
     "property=og:title": "Traefik Proxy, Frontend, Backend, Varnish container example"
     "keywords": "Plone 6, Container, Docker, Traefik Proxy, Frontend, Backend, Varnish"
 ---
 
 # Traefik Proxy, Frontend, Backend, ZEO, Varnish container example
 
-This example is a simple setup with one backend accessing a ZEO server and data being persisted in a Docker volume.
+This example is a basic setup with one backend accessing a ZEO server and data being persisted in a Docker volume.
 
 {term}`Traefik Proxy` in this example is used as a reverse proxy.
 

--- a/docs/install/containers/examples/traefik-volto-plone-varnish.md
+++ b/docs/install/containers/examples/traefik-volto-plone-varnish.md
@@ -402,7 +402,7 @@ services:
       - 8080:8080
     depends_on:
       - db
-#   If the docker container is run with another uid than the uid owning the local filesystem persistent storage,
+#   If the Docker container is run with a UID other than the UID which owns the local file system persistent storage,
 #   explicitly make the container run with the correct uid, for example  user: 1000:1000
 #   In that case make sure also the 'db' service gets the same 'user: 1000:1000' configuration,
 #   as they both need access to the filesystem


### PR DESCRIPTION
## Description

- remove obsolete 'version: 3' statements from docker-compose.yml files
- syntax change in Varnish v3: "Headers" statement needs to become "Header"
- make clear that for ZEO setups, it is necessary to set ZEO_SHARED_BLOB_DIR: on, otherwise the backend container will create its own filestorage/blobstorage setup
- add an explicit ZEO backend with persistent storage to the 'traefik-volto-plone-backend' example as otherwise the data lives in a hard-to-find randomly named volume





<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1963.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->