### PR TITLE
Added recipe to have an interactive shell when using docker

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -16,6 +16,8 @@ jobs:
       url: https://docs.plone.org
     steps:
       - uses: actions/checkout@v5
+        with:
+          submodules: true
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v2
       - name: Set up Python 3.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          submodules: true
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/docs/developer-guide/create-a-distribution.md
+++ b/docs/developer-guide/create-a-distribution.md
@@ -163,10 +163,14 @@ As an example, the configuration for a new Plone site with Volto as its frontend
     "plonetheme.barceloneta:default",
     "plone.volto:default"
   ],
-  "content": [
-    "plone.volto:default-homepage"
-  ]
+  "content": []
 }
+```
+
+```{note}
+The `plone.volto:default-homepage` profile was removed from `plone.volto` in version 5.
+For creating example content, use the `content` folder with exported content instead of profiles.
+See the {ref}`add-example-content-label` section below for details.
 ```
 
 
@@ -319,6 +323,8 @@ Finally, add it to your {file}`profiles.json` file.
 ```
 
 
+(add-example-content-label)=
+
 ## Add example content
 
 The distribution loads its content from JSON data in the `content` folder.
@@ -330,6 +336,11 @@ bin/export-distribution path/to/zope.conf Plone
 ```
 
 In the example above, `Plone` is the ID of the Plone site to export.
+
+```{note}
+This is the recommended approach for creating example content in distributions.
+The old approach of using profiles like `plone.volto:default-homepage` has been deprecated and removed from `plone.volto` in version 5.
+```
 
 
 ## Limit available distributions

--- a/docs/install/containers/images/frontend.md
+++ b/docs/install/containers/images/frontend.md
@@ -108,7 +108,8 @@ services:
     environment:
       - SITE=Plone
       - 'ADDONS=plone.restapi==8.21.0 plone.volto==4.0.0a3 plone.rest==2.0.0a2 plone.app.iterate==4.0.2 plone.app.vocabularies==4.3.0'
-      - 'PROFILES=plone.volto:default-homepage'
+      # Note: plone.volto:default-homepage profile was removed in version 5
+      # Use content export/import instead for example content
 
   frontend:
     image: 'myfrontend:latest'

--- a/docs/install/containers/recipes/index.md
+++ b/docs/install/containers/recipes/index.md
@@ -170,3 +170,89 @@ docker compose run backend pack
 The above command assumes that the service that runs the Plone instance is named `backend`.
 Otherwise replace `backend` with your container's name.
 
+
+## Interactive shell for debugging
+
+When developing or troubleshooting Plone applications in Docker containers, you may need an interactive Python shell with the Plone environment loaded.
+This is the Docker equivalent of the `bin/instance debug` command used in traditional Plone installations.
+
+### Using docker exec
+
+If you have a running Plone container, you can start an interactive shell using `docker exec`:
+
+```shell
+docker exec -it <container_name> /bin/bash
+```
+
+Once inside the container, you can start the Plone debug console:
+
+```shell
+bin/instance debug
+```
+
+### Using docker run
+
+Alternatively, you can start a new container instance specifically for debugging:
+
+```shell
+docker run -it --rm plone/plone-backend:{PLONE_BACKEND_MINOR_VERSION} /bin/bash
+```
+
+Then start the debug console:
+
+```shell
+bin/instance debug
+```
+
+### Using Docker Compose
+
+If you're using Docker Compose, you can run an interactive shell with:
+
+```shell
+docker compose exec backend /bin/bash
+```
+
+Then start the debug console:
+
+```shell
+bin/instance debug
+```
+
+Or run it directly in one command:
+
+```shell
+docker compose exec backend bin/instance debug
+```
+
+### Accessing the Plone site
+
+Once in the debug console, you can access your Plone site and perform debugging operations:
+
+```python
+# Access the root application
+app = self.app
+
+# Access your Plone site (replace 'Plone' with your site ID)
+site = app['Plone']
+
+# Access content
+folder = site['my-folder']
+item = folder['my-item']
+
+# Set up a fake request for testing
+from Testing.makerequest import makerequest
+from zope.globalrequest import setRequest
+
+app = makerequest(app)
+setRequest(app.REQUEST)
+```
+
+### Exiting the debug console
+
+To exit the debug console, use {kbd}`ctrl-d` or type `exit()`.
+
+```{note}
+The interactive shell provides full access to your Plone environment and database.
+Use it carefully in production environments.
+```
+


### PR DESCRIPTION
 
Issue number
Fixes #1960
Description:
Added documentation for interactive shell debugging when using Docker containers. This provides the Docker equivalent of the bin/instance debug command used in traditional Plone installations.
The new "Interactive shell for debugging" section in the Docker recipes documentation includes:
Multiple approaches for getting an interactive shell:
Using docker exec for running containers
Using docker run for new container instances
Using docker compose exec for Docker Compose setups
Practical examples showing how to access the Plone site and set up fake requests
Safety warnings about using this in production environments.

LINK:
https://6.docs.plone.org/install/containers/recipes/index.html

MESSAGE:
The issue being fixed #1960
 Interactive shell debugging documentation was added in Docker recipes page.


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1967.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->