### PR TITLE
Add glossary terms and Vale spellings `Public UI` and `CMSUI`.

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -920,4 +920,13 @@ blob
 Binary large object
     A blob is a mass of data in binary form that does not necessarily conform to any file format.
 
+content management system user interface
+CMSUI
+    In Seven, the content management system user interface (CMSUI) is the editor and administrator part of the app.
+    Its counterpart is the {term}`Public UI`.
+   
+Public UI
+    In Seven, Public UI is the end user interface part, which displays content to both authenticated and anonymous users.
+    Its counterpart is the {term}`CMSUI`.
+ 
 ```

--- a/styles/config/vocabularies/Plone/accept.txt
+++ b/styles/config/vocabularies/Plone/accept.txt
@@ -13,6 +13,7 @@ bugfix
 buildout
 cacheable
 Classic UI
+CMSUI
 CommonJS
 Cookieplone
 doctest
@@ -39,6 +40,7 @@ pluggab(le|ility)
 [Pp]ortlets?
 prerendered
 programatically
+Public UI
 [Qq]uerystring
 Razzle
 [Rr]enderers?


### PR DESCRIPTION
See https://github.com/plone/volto/issues/7385 and https://github.com/plone/volto/pull/7375

This needs to be merged first so that the Volto PR can pull in glossary terms via Intersphinx.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1975.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->