### PR TITLE
Add missing glossary terms: contentIcons and excludeLinksAndReferencesMenuItem

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -208,14 +208,13 @@ Volto configuration loader
 
 (contentIcons)=
 contentIcons
-A Volto configuration option (typically a boolean) that controls whether small content-type icons are shown next to items in lists, teasers, and navigation components.  
-When enabled, an icon representing the item's content type (for example: document, image, file) is displayed alongside the item's title.
+    A Volto configuration option (typically a boolean) that controls whether small content-type icons are shown next to items in lists, teasers, and navigation components.
+    When enabled, an icon representing the item's content type (for example: document, image, file) is displayed alongside the item's title.
 
 (excludeLinksAndReferencesMenuItem)=
 excludeLinksAndReferencesMenuItem
-A Volto configuration key or menu setting that, when enabled, removes or hides the "Links and References" menu item from link pickers or site menus.  
-Use this option to prevent the Links and References entry from appearing in UI menus where it is not desired.
-
+    A Volto configuration key or menu setting that, when enabled, removes or hides the "Links and References" menu item from link pickers or site menus.
+    Use this option to prevent the Links and References entry from appearing in UI menus where it is not desired.
 
 Configuration registry
     In Plone and in general, the configuration registry is where resources are registered for an application.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -206,6 +206,17 @@ Volto configuration loader
     An add-on must provide a default configuration loader that is always loaded when Volto runs.
     An add-on can have multiple configuration loaders, and they can be loaded optionally from the Volto configuration.
 
+(contentIcons)=
+contentIcons
+A Volto configuration option (typically a boolean) that controls whether small content-type icons are shown next to items in lists, teasers, and navigation components.  
+When enabled, an icon representing the item's content type (for example: document, image, file) is displayed alongside the item's title.
+
+(excludeLinksAndReferencesMenuItem)=
+excludeLinksAndReferencesMenuItem
+A Volto configuration key or menu setting that, when enabled, removes or hides the "Links and References" menu item from link pickers or site menus.  
+Use this option to prevent the Links and References entry from appearing in UI menus where it is not desired.
+
+
 Configuration registry
     In Plone and in general, the configuration registry is where resources are registered for an application.
 


### PR DESCRIPTION
Fixes: #7609

Issue: Fixes missing glossary warnings for contentIcons and excludeLinksAndReferencesMenuItem.

This pull request adds two missing glossary terms that were causing Sphinx warnings during the documentation build:

contentIcons

excludeLinksAndReferencesMenuItem

Both terms are referenced in the Volto documentation but were not defined in glossary.md.
Adding them resolves the Sphinx build warnings reported in the issue.

Not applicable — this change only adds glossary entries (no UI changes).



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1986.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->