### PR TITLE
Add glossary entries: contentIcons, excludeLinksAndReferencesMenuItem

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -55,6 +55,14 @@ plone/generator-volto
 cookiecutter-zope-instance
     [cookiecutter-zope-instance](https://github.com/plone/cookiecutter-zope-instance) is a cookiecutter template to create a full and complex configuration of a {term}`Zope instance`.
 
+contentIcons
+    Icons used in the {term}`Volto` UI to visually represent different content types, such as pages, files, news items, or custom content types.  
+    These icons help users quickly identify the type of content they are interacting with.
+
+excludeLinksAndReferencesMenuItem
+    A menu item in {term}`Volto` that allows a view to exclude links and references from being displayed.  
+    This is useful for creating simplified or focused views where only the main content is shown, without additional references or navigation links.
+
 CSRF
 Cross-Site Request Forgery
     Cross-Site Request Forgery (CSRF or XSRF) is a type of web attack that allows an attacker to send malicious requests to a web application on behalf of a legitimate user.


### PR DESCRIPTION
## Issue number

- Fixes #7609

## Description
Added missing glossary entries for contentIcons and excludeLinksAndReferencesMenuItem in docs/glossary.md.
These entries explain the purpose and usage of these features in Plone documentation.

## Add screenshots or links to a preview of the changes
<img width="1320" height="581" alt="Screenshot from 2025-11-12 18-21-35" src="https://github.com/user-attachments/assets/57058b73-ce14-4dec-9b17-7a43d16aca0c" />

<img width="1320" height="581" alt="Screenshot from 2025-11-12 18-21-55" src="https://github.com/user-attachments/assets/7adcecc4-b51c-49c2-a3c7-c595cdf079ab" />



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1987.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->