### PR TITLE
Fixes pull request template links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,9 @@ Thank you for your contribution to the Plone Documentation.
 Before submitting this pull request, please make sure you follow our guides:
 
 -   [Contributing to Plone documentation](https://6.docs.plone.org/contributing/index.html)
--   [Building and checking the quality of documentation](https://6.docs.plone.org/contributing/setup-build.html)
--   [Authors guide](https://6.docs.plone.org/contributing/authors.html)
--   [MyST reference](https://6.docs.plone.org/contributing/myst-reference.html)
+-   [Building and checking the quality of documentation](https://6.docs.plone.org/contributing/documentation/setup-build.html)
+-   [Authors guide](https://6.docs.plone.org/contributing/documentation/authors.html)
+-   [MyST reference](https://6.docs.plone.org/contributing/documentation/myst-reference.html)
 
 ## Issue number
 


### PR DESCRIPTION
## Issue number

- Fixes #1993

## Description

Fixes pull request template contribution guidelines links



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--1994.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->