### PR TITLE
Align wheel version with dist for 6.1.3

### DIFF
--- a/requirements-initial.txt
+++ b/requirements-initial.txt
@@ -2,4 +2,4 @@
 # From https://dist.plone.org/release/6.1.3/constraints.txt
 pip==25.2
 setuptools==80.9.0
-wheel==0.46.1
+wheel==0.45.1


### PR DESCRIPTION
From https://dist.plone.org/release/6.1.3/constraints.txt

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2005.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->