### PR TITLE
Add documentation for disabling GlyphIcons in Classic UI

### DIFF
--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -56,7 +56,6 @@ For example, remove any references similar to:
 
 ## Registration
 
-
 Icons are registered in Plone's registry.
 This provides an option to customize the content type and Plone UI icons by overriding icons via XML.
 Plone ships with the following icon registrations by default.

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -33,7 +33,7 @@ See the file [package.json](https://github.com/plone/plone.staticresources/blob/
 
 (classic-ui-icons-disable-glyphicons-label)=
 
-## Disabling GlyphIcons
+## Disable GLYPHICONS®
 
 Plone Classic UI does not use GlyphIcons by default in Plone 6, as Bootstrap Icons are the preferred icon set.
 However, in some projects or legacy setups, GlyphIcons may still be loaded or referenced through custom themes or add-ons.

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -35,7 +35,7 @@ See the file [package.json](https://github.com/plone/plone.staticresources/blob/
 
 ## Disable GLYPHICONS®
 
-Plone Classic UI does not use GlyphIcons by default in Plone 6, as Bootstrap Icons are the preferred icon set.
+Plone Classic UI does not use [GLYPHICONS](https://www.glyphicons.com/) by default in Plone 6, as [Bootstrap Icons](https://icons.getbootstrap.com/) are the preferred icon set.
 However, in some projects or legacy setups, GlyphIcons may still be loaded or referenced through custom themes or add-ons.
 
 If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -36,7 +36,7 @@ See the file [package.json](https://github.com/plone/plone.staticresources/blob/
 ## Disable GLYPHICONS®
 
 Plone Classic UI does not use [GLYPHICONS](https://www.glyphicons.com/) by default in Plone 6, as [Bootstrap Icons](https://icons.getbootstrap.com/) are the preferred icon set.
-However, in some projects or legacy setups, GlyphIcons may still be loaded or referenced through custom themes or add-ons.
+However, in some projects or legacy setups, GLYPHICONS may still be loaded or referenced through custom themes or add-ons.
 
 If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.
 

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -31,9 +31,31 @@ Icons are shipped via `plone.staticresources`.
 See the file [package.json](https://github.com/plone/plone.staticresources/blob/master/package.json) of the package to get the actual version of the icons in Plone.
 
 
+(classic-ui-icons-disable-glyphicons-label)=
+
+## Disabling GlyphIcons
+
+Plone Classic UI does not use GlyphIcons by default in Plone 6, as Bootstrap Icons are the preferred icon set.
+However, in some projects or legacy setups, GlyphIcons may still be loaded or referenced through custom themes or add-ons.
+
+If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.
+
+### Disable GlyphIcons in Classic UI
+
+Ensure that your theme or add-on does **not** include GlyphIcons CSS or resources.
+If GlyphIcons are loaded via custom Diazo rules, theme bundles, or legacy add-ons, remove those references.
+
+For example, remove any references similar to:
+
+```html
+<link rel="stylesheet" href="++plone++static/glyphicons.css" />
+```
+
+
 (classic-ui-icons-registration-label)=
 
 ## Registration
+
 
 Icons are registered in Plone's registry.
 This provides an option to customize the content type and Plone UI icons by overriding icons via XML.

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -39,7 +39,7 @@ Plone Classic UI does not use [GLYPHICONS](https://www.glyphicons.com/) by defau
 However, in some projects or legacy setups, GLYPHICONS may still be loaded or referenced through custom themes or add-ons.
 
 If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.
-Ensure that your theme or add-on does **not** include GlyphIcons CSS or resources.
+Ensure that your theme or add-on does _not_ include GLYPHICONS CSS or resources.
 If GlyphIcons are loaded via custom Diazo rules, theme bundles, or legacy add-ons, remove those references.
 
 For example, remove any references similar to:

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -42,7 +42,7 @@ If you want to explicitly disable GlyphIcons to avoid loading unused assets or t
 Ensure that your theme or add-on does _not_ include GLYPHICONS CSS or resources.
 If GLYPHICONS are loaded via custom Diazo rules, theme bundles, or legacy add-ons, then remove those references.
 
-For example, remove any references similar to:
+For example, remove any references similar to the following.
 
 ```html
 <link rel="stylesheet" href="++plone++static/glyphicons.css" />

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -39,9 +39,6 @@ Plone Classic UI does not use [GLYPHICONS](https://www.glyphicons.com/) by defau
 However, in some projects or legacy setups, GLYPHICONS may still be loaded or referenced through custom themes or add-ons.
 
 If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.
-
-### Disable GlyphIcons in Classic UI
-
 Ensure that your theme or add-on does **not** include GlyphIcons CSS or resources.
 If GlyphIcons are loaded via custom Diazo rules, theme bundles, or legacy add-ons, remove those references.
 

--- a/docs/classic-ui/icons.md
+++ b/docs/classic-ui/icons.md
@@ -40,7 +40,7 @@ However, in some projects or legacy setups, GLYPHICONS may still be loaded or re
 
 If you want to explicitly disable GlyphIcons to avoid loading unused assets or to prevent accidental usage, you can do so by removing or overriding the related resources.
 Ensure that your theme or add-on does _not_ include GLYPHICONS CSS or resources.
-If GlyphIcons are loaded via custom Diazo rules, theme bundles, or legacy add-ons, remove those references.
+If GLYPHICONS are loaded via custom Diazo rules, theme bundles, or legacy add-ons, then remove those references.
 
 For example, remove any references similar to:
 


### PR DESCRIPTION
### What this PR does

Adds a new documentation section explaining how to disable GlyphIcons in Plone 6 Classic UI.

### Why this is needed

Although GlyphIcons are no longer used by default in Plone 6, legacy themes or add-ons may still load them.
This documentation helps developers explicitly remove unused GlyphIcons resources and avoid accidental usage.

### Scope

- Documentation-only change
- No code or behavior changes

Closes #694


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2006.org.readthedocs.build/classic-ui/icons.html

<!-- readthedocs-preview plone6 end -->