### PR TITLE
Add MyST examples for menuselection and guilabel roles

### DIFF
--- a/docs/contributing/documentation/myst-reference.md
+++ b/docs/contributing/documentation/myst-reference.md
@@ -394,6 +394,25 @@ print("my 1st line")
 print(f"my {a}nd line")
 ```
 ````
+### GUI-related roles
+
+Use the following MyST roles to document interactions with graphical user interfaces.
+
+#### `guilabel`
+
+Use the `guilabel` role to refer to labels in a graphical user interface, such as buttons, menu items, or tabs.
+
+```{example}
+Click the {guilabel}`Save` button to store your changes.
+```
+
+#### `menuselection`
+
+Use the `menuselection` role to describe a sequence of menu selections in a graphical user interface.
+
+```{example}
+Navigate to {menuselection}`File --> Preferences --> Settings`.
+```
 
 ### Tabs
 

--- a/docs/contributing/documentation/myst-reference.md
+++ b/docs/contributing/documentation/myst-reference.md
@@ -394,6 +394,8 @@ print("my 1st line")
 print(f"my {a}nd line")
 ```
 ````
+
+
 ### GUI-related roles
 
 Use the following MyST roles to document interactions with graphical user interfaces.


### PR DESCRIPTION
## Issue number

- Fixes #2007

## Description

This pull request adds documentation examples for the MyST roles guilabel and menuselection in the MyST reference.
The new section explains when to use each role and provides simple examples for documenting graphical user interface interactions.
The content is placed immediately after the Code block section, as requested in the issue.



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2011.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->