### PR TITLE
TinyMCE license key configuration docs

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -94,8 +94,8 @@ You should rename your override to the new location if you no longer need compat
 
 ## TinyMCE 8 for Classic UI
 
-The WYSIWYG editor for Classic UI {glossary}`TinyMCE` was updated to Version 8.
+The {term}`WYSIWYG` editor for Classic UI, {glossary}`TinyMCE`, was updated to version 8.
 
-You are now able to provide your commercial license in the {menuitem}`TinyMCE controlpanel`.
+You're now able to enter your commercial license key in the {menuitem}`TinyMCE` control panel.
 
-See this {doc}`guide </classic-ui/tinymce-customizations>` for setup instructions.
+See {doc}`/classic-ui/tinymce-customizations` for setup instructions.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -98,4 +98,4 @@ The {term}`WYSIWYG` editor for Classic UI, {glossary}`TinyMCE`, was updated to v
 
 You're now able to enter your commercial license key in the {menuitem}`TinyMCE` control panel.
 
-See {doc}`/classic-ui/tinymce-customizations` for setup instructions.
+See {doc}`/classic-ui/tinymce-customization` for setup instructions.

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -94,7 +94,7 @@ You should rename your override to the new location if you no longer need compat
 
 ## TinyMCE 8 for Classic UI
 
-The {term}`WYSIWYG` editor for Classic UI, {glossary}`TinyMCE`, was updated to version 8.
+The {term}`WYSIWYG` editor for Classic UI, {term}`TinyMCE`, was updated to version 8.
 
 You're now able to enter your commercial license key in the {menuitem}`TinyMCE` control panel.
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -91,3 +91,11 @@ This is because we keep a mapping from the old to the new location.
 For example, `plone.locking` registers that `plone.locking.browser.info.pt` has a new location, `plone.app.layout.viewlets.locking.pt`.
 You should rename your override to the new location if you no longer need compatibility with Plone 6.1 or earlier.
 ```
+
+## TinyMCE 8 for Classic UI
+
+The WYSIWYG editor for Classic UI {glossary}`TinyMCE` was updated to Version 8.
+
+You are now able to provide your commercial license in the {menuitem}`TinyMCE controlpanel`.
+
+See this {doc}`guide </classic-ui/tinymce-customizations>` for setup instructions.

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -220,11 +220,11 @@ See more information in the [TinyMCE licensing documentation](https://www.tiny.c
 If you have a TinyMCE license before version 8, read the important [License key migration documentation](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/#license-key-system-update).
 
 
-### Setup commercial license key manager plugin
+### Commercial license key manager plugin
 
 Since we can't provide the license key manager plugin out of the box, because this is only shipped with a paid TinyMCE package, you have to provide the plugin in your own add-on package.
 
-See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/tinymce/latest/license-key/#setting-up-the-commercial-license-key-manager) for more information how to get the plugin.
+See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/tinymce/latest/license-key/#setting-up-the-commercial-license-key-manager) for more information of how to get the plugin.
 
 You have to provide the plugin file as a static resource and register it in {menuselection}`Site Setup --> TinyMCE --> Plugins and Toolbar -> Custom plugins` as shown.
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -222,7 +222,7 @@ If you have a TinyMCE license before version 8, read the important [License key 
 
 ### Setup commercial license key manager plugin
 
-Since we cannot provide the license key manager plugin out of the box, because this is only shipped with a paid TinyMCE package, you have to provide the plugin in your own addon package.
+Since we can't provide the license key manager plugin out of the box, because this is only shipped with a paid TinyMCE package, you have to provide the plugin in your own add-on package.
 
 See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/tinymce/latest/license-key/#setting-up-the-commercial-license-key-manager) for more information how to get the plugin.
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -226,7 +226,7 @@ Since we can't provide the license key manager plugin out of the box, because th
 
 See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/tinymce/latest/license-key/#setting-up-the-commercial-license-key-manager) for more information how to get the plugin.
 
-You have to provide the plugin file as a static resource and register it in {menuselection}`Site Setup --> TinyMCE --> Plugins and Toolbar -> Custom plugins` like this:
+You have to provide the plugin file as a static resource and register it in {menuselection}`Site Setup --> TinyMCE --> Plugins and Toolbar -> Custom plugins` as shown.
 
 ```text
 licensekeymanager|++plone++path.to.licensekeymanager.resource.js

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -228,7 +228,7 @@ See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/
 
 You have to provide the plugin file as a static resource and register it in {menuselection}`Site Setup --> TinyMCE --> Plugins and Toolbar -> Custom plugins` like this:
 
-```
+```text
 licensekeymanager|++plone++path.to.licensekeymanager.resource.js
 ```
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -211,7 +211,7 @@ This makes it easier to maintain and reuse your registry files.
 ```{versionadded} Plone 6.2
 ```
 
-If you own a commercial TinyMCE license, you can provide the key in {menuselection}`Site Setup --> TinyMCE --> Advanced`.
+If you own a commercial TinyMCE license, you can enter the key in the control panel {menuselection}`Site Setup --> TinyMCE --> Advanced`.
 
 The TinyMCE 8 commercial license key will have a `T8LK:` prefix.
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -215,7 +215,7 @@ If you own a commercial TinyMCE license, you can provide the key in {menuselecti
 
 The TinyMCE 8 commercial license key will have a `T8LK:` prefix.
 
-See more information in the [TinyMCE licensing documentation](https://www.tiny.cloud/docs/tinymce/latest/license-key/)
+See more information in the [TinyMCE licensing documentation](https://www.tiny.cloud/docs/tinymce/latest/license-key/).
 
 If you have a TinyMCE license before version 8, read the important [License key migration documentation](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/#license-key-system-update)
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -205,3 +205,36 @@ The file {file}`profiles/default/registry.xml` can be split in several files in 
 the directory `profiles/default/registry` with arbitrary names ending in `.xml`.
 This makes it easier to maintain and reuse your registry files.
 ```
+
+## Use TinyMCE with a commercial license
+
+If you own a commercial TinyMCE license, you can provide the key in {menuselection}`Site Setup --> TinyMCE --> Advanced`
+
+The TinyMCE 8 commercial license key will have a `T8LK:` prefix.
+
+See more information in the [TinyMCE licensing documentation](https://www.tiny.cloud/docs/tinymce/latest/license-key/)
+
+If you have a TinyMCE license before version 8, read the important [License key migration documentation](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/#license-key-system-update)
+
+
+### Setup commercial license key manager plugin
+
+Since we cannot provide the license key manager plugin out of the box, because this is only shipped with a paid TinyMCE package, you have to provide the plugin in your own addon package.
+
+See [Setting up the Commercial License Key Manager](https://www.tiny.cloud/docs/tinymce/latest/license-key/#setting-up-the-commercial-license-key-manager) for more information how to get the plugin.
+
+You have to provide the plugin file as a static resource and register it in {menuselection}`Site Setup --> TinyMCE --> Plugins and Toolbar -> Custom plugins` like this:
+
+```
+licensekeymanager|++plone++path.to.licensekeymanager.resource.js
+```
+
+You can also provide this value in your add-on GenericSetup configuration, such as {file}`profiles/default/registry/tinymce.xml`.
+
+```xml
+<records prefix="plone" interface="plone.base.interfaces.controlpanel.ITinyMCESchema">
+  <value key="custom_plugins" purge="false">
+    <element>licensekeymanager|++plone++path.to.licensekeymanager.resource.js</element>
+  </value>
+</records>
+```

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -217,7 +217,7 @@ The TinyMCE 8 commercial license key will have a `T8LK:` prefix.
 
 See more information in the [TinyMCE licensing documentation](https://www.tiny.cloud/docs/tinymce/latest/license-key/).
 
-If you have a TinyMCE license before version 8, read the important [License key migration documentation](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/#license-key-system-update)
+If you have a TinyMCE license before version 8, read the important [License key migration documentation](https://www.tiny.cloud/docs/tinymce/latest/migration-from-7x/#license-key-system-update).
 
 
 ### Setup commercial license key manager plugin

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -211,7 +211,7 @@ This makes it easier to maintain and reuse your registry files.
 ```{versionadded} Plone 6.2
 ```
 
-If you own a commercial TinyMCE license, you can provide the key in {menuselection}`Site Setup --> TinyMCE --> Advanced`
+If you own a commercial TinyMCE license, you can provide the key in {menuselection}`Site Setup --> TinyMCE --> Advanced`.
 
 The TinyMCE 8 commercial license key will have a `T8LK:` prefix.
 

--- a/docs/classic-ui/tinymce-customization.md
+++ b/docs/classic-ui/tinymce-customization.md
@@ -208,6 +208,9 @@ This makes it easier to maintain and reuse your registry files.
 
 ## Use TinyMCE with a commercial license
 
+```{versionadded} Plone 6.2
+```
+
 If you own a commercial TinyMCE license, you can provide the key in {menuselection}`Site Setup --> TinyMCE --> Advanced`
 
 The TinyMCE 8 commercial license key will have a `T8LK:` prefix.


### PR DESCRIPTION
This will come to Plone 6.2 only ... how can we mark this in the documentation?

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: 

- https://plone6--2012.org.readthedocs.build/classic-ui/tinymce-customization.html#use-tinymce-with-a-commercial-license
- https://plone6--2012.org.readthedocs.build/backend/upgrading/version-specific-migration/upgrade-to-62.html

<!-- readthedocs-preview plone6 end -->