### PR TITLE
Revise first-time guide to clarify the meaning of labels for GitHub i…

### DIFF
--- a/docs/contributing/first-time.md
+++ b/docs/contributing/first-time.md
@@ -154,8 +154,23 @@ Please don't be "that person".
     Working on documentation or on issues labeled with either [`33 needs: docs`](https://github.com/search?q=user%3Aplone+label%3A%2233+needs%3A+docs%22&type=issues&ref=advsearch) or [`41 lvl: easy`](https://github.com/search?q=user%3Aplone+label%3A%2241+lvl%3A+easy%22&type=Issues&ref=advsearch) are the two best ways for first-time contributors to contribute.
     This is because first-timers have a fresh perspective that might be overlooked by old-timers.
     
-    Issues labeled `42 lvl: moderate`, `43 lvl: complex`, or `03 type: feature (plip)` are not suitable for first-timers because of their complexity.
+    ```{warning}
+    Don't work on issues with any of the following labels.
+    
+    Issues with any of the following labels are not suitable for first-timers because of their complexity.
     Issues with these labels may take weeks to complete.
+
+    -   {guilabel}`42 lvl: moderate`
+    -   {guilabel}`43 lvl: complex`
+    -   {guilabel}`03 type: feature (plip)`
+
+    Issues with any of the following labels are not ready to develop.
+    They must be verified, discussed, and clarified before work can begin.
+
+    -   {guilabel}`30 needs: triage`
+    -   {guilabel}`30.1 needs: confirmation`
+    ```
+
 1.  **Discuss whether you should perform any work.**
     First see {ref}`Avoid duplicate effort <mistake-2-label>`.
     Next, any discussion method listed below is acceptable, and they are listed in the order of most likely to get a response.

--- a/docs/contributing/first-time.md
+++ b/docs/contributing/first-time.md
@@ -69,7 +69,12 @@ Such motivation behind these contributions usually results in poor quality break
 All first-time contributors to Plone must follow the contributing requirements described in {doc}`index`.
 Although you can open a pull request at any time, Plone Team members may ignore it until, or close it unless, you satisfy the contributing requirements.
 
+```{warning}
 For [Plone Google Summer of Code (GSoC)](https://plone.org/community/gsoc) applicants, you must also follow both our and its program guidelines.
+Failure to do so may result in your suspension or banishment from the Plone GitHub organization.
+Additionally, it will prevent you from being selected to participate in GSoC.
+Check each year's program guidelines for details.
+```
 
 
 (contributing-make-contributions-through-github-label)=

--- a/docs/contributing/first-time.md
+++ b/docs/contributing/first-time.md
@@ -160,7 +160,7 @@ Please don't be "that person".
     This is because first-timers have a fresh perspective that might be overlooked by old-timers.
     
     ```{warning}
-    Don't work on issues with any of the following labels.
+    Don't write code or documentation for issues with any of the following labels.
     
     Issues with any of the following labels are not suitable for first-timers because of their complexity.
     Issues with these labels may take weeks to complete.
@@ -171,7 +171,8 @@ Please don't be "that person".
 
     Issues with any of the following labels are not ready to develop.
     They must be verified, discussed, and clarified before work can begin.
-
+    You may verify them, which is a helpful way to move the issue forward, but you should not write code or documentation for them until a clear plan of action has been established in the issue.
+    
     -   {guilabel}`30 needs: triage`
     -   {guilabel}`30.1 needs: confirmation`
     ```


### PR DESCRIPTION
…ssues

We're getting lots of inquiries from overly eager first-time contributors and GSoC applicants to start work on issues that haven't been verified or discussed or for which they aren't qualified. This PR aims to direct first-timers away from pitfalls and hopefully reduce their distracting behavior.

Although this primarily affects the Volto repo, I've seen a few more in other projects that I can't locate at the moment. See:

- https://github.com/plone/volto/issues/7709
- https://github.com/plone/volto/pull/7729
- https://github.com/plone/volto/issues/6171#issuecomment-3650719984
- https://github.com/plone/volto/issues/7335

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2014.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->