### PR TITLE
Fix broken links

### DIFF
--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -31,7 +31,7 @@ Native namespaces are also referred to as implicit namespaces.
 The two terms mean the same.
 
 ```{seealso}
-- [Python Packaging Guide on native namespaces](https://packaging.python.org/en/latest/guides/.packaging-namespace-packages/#native-namespace-packages)
+- [Python Packaging Guide on native namespaces](https://packaging.python.org/en/latest/guides/packaging-namespace-packages/#native-namespace-packages)
 - [PEP 420 - Implicit Namespace Packages](https://peps.python.org/pep-0420/)
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,6 +89,7 @@ linkcheck_ignore = [
     r"https://github.com/orgs/plone/teams/",
     r"https://github.com/plone/documentation/issues/new",
     r"https://classic.demo.plone.org/en/demo/an-image.jpg/@@images-test#srcset",
+    r"https://javascript.plainenglish.io/you-dont-need-lodash-how-i-gave-up-lodash-693c8b96a07c",
     # Ignore pages that are rate limited or otherwise blocked
     r"https://stackoverflow.com",
     r"https://www.npmjs.com/",

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -731,7 +731,7 @@ acquisition
     Acquisition is a mechanism that allows objects to inherit attributes from their parent objects in the object hierarchy.
 
 Varnish
-    [Varnish](https://varnish-cache.org) is a popular open source web accelerator that is used to implement HTTP caching.
+    [Varnish](https://vinyl-cache.org/) is a popular open source web accelerator that is used to implement HTTP caching.
 
 Content Delivery Network
 CDN


### PR DESCRIPTION
https://github.com/plone/volto/pull/7741 must be merged first, then submodules updated.

- Exclude link that requires authentication
- Varnish Cache is now Vinyl Cache. See https://vinyl-cache.org/#years-old-and-it-is-time-to-get-serious-er
- Fix typo

See also https://github.com/collective/awesome-volto/pull/52

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2015.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->