### PR TITLE
Updated make acceptance test cookieplone-template make commands descriptions

### DIFF
--- a/docs/reference-guide/cookieplone-make-commands.md
+++ b/docs/reference-guide/cookieplone-make-commands.md
@@ -142,6 +142,38 @@ You can run the following make targets by using the command structure of `make <
     This runs unit tests in the project.
 
 
+## Acceptance
+
+When you issue a `make` command at the root of your project, you call the file {file}`Makefile` also at the root.
+In turn, it invokes commands in the files {file}`backend/Makefile` and {file}`frontend/Makefile`.
+You can refer to these files for implementation details.
+You can run the following make targets by using the command structure of `make <TARGET>`.
+
+`acceptance-backend-start`
+:   Invokes the target `acceptance-backend-start` in `backend/Makefile`.
+    This starts a Plone backend configured for acceptance testing.
+
+`acceptance-frontend-dev-start`
+:   Invokes the target `acceptance-frontend-dev-start` in `frontend/Makefile`.
+    This starts the Volto frontend in development mode for acceptance testing.
+
+`acceptance-test`
+:   Invokes the target `acceptance-test` in `frontend/Makefile`.
+    This runs acceptance tests in interactive mode.
+
+`acceptance-images-build`
+:   Builds both backend and frontend Docker images for acceptance testing.
+
+`acceptance-containers-start`
+:   Starts backend and frontend acceptance Docker containers.
+
+`acceptance-containers-stop`
+:   Stops the running acceptance Docker containers.
+
+`ci-acceptance-test`
+:   Runs acceptance tests in CI mode using Docker containers.
+
+
 ## Container images
 
 When you issue a `make` command at the root of your project, you call the file {file}`Makefile` also at the root.

--- a/docs/reference-guide/cookieplone-make-commands.md
+++ b/docs/reference-guide/cookieplone-make-commands.md
@@ -142,7 +142,7 @@ You can run the following make targets by using the command structure of `make <
     This runs unit tests in the project.
 
 
-## Acceptance
+## Acceptance tests
 
 When you issue a `make` command at the root of your project, you call the file {file}`Makefile` also at the root.
 In turn, it invokes commands in the files {file}`backend/Makefile` and {file}`frontend/Makefile`.
@@ -150,15 +150,15 @@ You can refer to these files for implementation details.
 You can run the following make targets by using the command structure of `make <TARGET>`.
 
 `acceptance-backend-start`
-:   Invokes the target `acceptance-backend-start` in `backend/Makefile`.
+:   Invokes the target `acceptance-backend-start` in {file}`backend/Makefile`.
     This starts a Plone backend configured for acceptance testing.
 
 `acceptance-frontend-dev-start`
-:   Invokes the target `acceptance-frontend-dev-start` in `frontend/Makefile`.
+:   Invokes the target `acceptance-frontend-dev-start` in {file}`frontend/Makefile`.
     This starts the Volto frontend in development mode for acceptance testing.
 
 `acceptance-test`
-:   Invokes the target `acceptance-test` in `frontend/Makefile`.
+:   Invokes the target `acceptance-test` in {file}`frontend/Makefile`.
     This runs acceptance tests in interactive mode.
 
 `acceptance-images-build`


### PR DESCRIPTION
## Fixes #1943



## Description

Added a missing section for acceptance commands in cookieplone-template make commands description


This PR is in accordance with https://github.com/plone/cookieplone-templates/pull/323
In https://github.com/plone/cookieplone-templates/pull/323 , I have removed the `-dev` from `acceptance-backend-dev-start`.
So I have did the same for documentation also,  As the issues for these PRs were inter-related.



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2017.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->