### PR TITLE
Docs: clarify requirement for unique theme names

### DIFF
--- a/docs/classic-ui/theming/index.md
+++ b/docs/classic-ui/theming/index.md
@@ -29,6 +29,9 @@ The customized Barceloneta theme, creating a theme from scratch, and Diazo offer
 Barceloneta theme
 :   Ideal for a starting point, especially if you want to tweak it as an existing, solid theme.
     You can customize its components and styles without starting from zero.
+ > **Note:** When creating a new theme based on Barceloneta, you must give the theme a unique name. This includes renaming the theme folder and updating the `title` value in `manifest.cfg` before creating the ZIP file. Otherwise, uploading the theme may fail with an override error.
+
+
 
 From scratch
 :   If your project requires something completely unique and none of the existing themes fit, building a theme from scratch would be the way to go.


### PR DESCRIPTION
Added a note explaining the need to rename the theme folder and update manifest.cfg when creating a new theme.

## First-time contributors

You **must** read and follow our [First-time contributors](https://6.docs.plone.org/contributing/first-time.html).

---

## Submit a pull request

Thank you for your contribution to the Plone Documentation.

Before submitting this pull request, please make sure you follow our guides:

-   [Contributing to Plone documentation](https://6.docs.plone.org/contributing/index.html)
-   [Building and checking the quality of documentation](https://6.docs.plone.org/contributing/documentation/setup-build.html)
-   [Authors guide](https://6.docs.plone.org/contributing/documentation/authors.html)
-   [MyST reference](https://6.docs.plone.org/contributing/documentation/myst-reference.html)

## Issue number

- Fixes #106

## Description

This PR clarifies the Classic UI theming documentation by explaining that a unique theme name is required when creating a new theme from an existing one.
It notes that the theme folder must be renamed and the title updated in manifest.cfg before creating the ZIP file, to avoid override errors.
This addresses the confusion described in issue #106.


## Add screenshots or links to a preview of the changes



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2022.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->