### PR TITLE
Adding related content

### DIFF
--- a/docs/admin-guide/zope-manager-users.md
+++ b/docs/admin-guide/zope-manager-users.md
@@ -107,6 +107,7 @@ When you run the script, if the user already exists:
     Maybe the user already exists and nothing is done then.
     Or the implementation does not give info when it succeeds.
     ```
+
 ## Related content
 
 -   {doc}`/admin-guide/run-plone`

--- a/docs/admin-guide/zope-manager-users.md
+++ b/docs/admin-guide/zope-manager-users.md
@@ -107,3 +107,7 @@ When you run the script, if the user already exists:
     Maybe the user already exists and nothing is done then.
     Or the implementation does not give info when it succeeds.
     ```
+## Related content
+
+-   {doc}`/admin-guide/run-plone`
+-   {doc}`/admin-guide/override-core`

--- a/docs/conceptual-guides/choose-user-interface.md
+++ b/docs/conceptual-guides/choose-user-interface.md
@@ -70,3 +70,7 @@ For developers and integrators:
 
 ````
 `````
+## Related content
+
+-   {doc}`/volto/index`
+-   {doc}`/classic-ui/index`

--- a/docs/conceptual-guides/choose-user-interface.md
+++ b/docs/conceptual-guides/choose-user-interface.md
@@ -70,6 +70,7 @@ For developers and integrators:
 
 ````
 `````
+
 ## Related content
 
 -   {doc}`/volto/index`

--- a/docs/conceptual-guides/compare-buildout-pip.md
+++ b/docs/conceptual-guides/compare-buildout-pip.md
@@ -38,3 +38,8 @@ The choice of installation tool has implications for admins and developers.
 ```{seealso}
 [Proposal: Use pip constraints as canonical version location #3670](https://github.com/plone/Products.CMFPlone/issues/3670)
 ```
+
+## Related content
+
+-   {doc}`/admin-guide/install-buildout`
+-   {doc}`/admin-guide/install-pip`


### PR DESCRIPTION
## Issue number

- Contributes to #1973 

## Description
This pull request adds **Related content** sections to selected Plone 6 documentation pages to improve discoverability and navigation for readers.

The following pages were updated:

- `docs/admin-guide/zope-manager-users`
- `docs/conceptual-guides/choose-user-interface`
- `docs/conceptual-guides/compare-buildout-pip`

## Add screenshots or links to a preview of the changes

Preview for `docs/admin-guide/zope-manager-users`
<img width="1087" height="594" alt="{3F9C25AE-DC68-46F3-BEDB-2295F2BBA36C}" src="https://github.com/user-attachments/assets/fedb829d-c63f-4604-84a3-624619492ef9" />

Preview for `docs/conceptual-guides/choose-user-interface`
<img width="1236" height="655" alt="{CAE1FE80-1FAD-452A-A7E5-B8BA6E94861B}" src="https://github.com/user-attachments/assets/96a6ab85-ad85-4fdc-b6b3-279d189f80a8" />

Preview for `docs/conceptual-guides/compare-buildout-pip`
<img width="1076" height="611" alt="{5C8F46D7-5FAB-4B01-9929-FBD4686AE973}" src="https://github.com/user-attachments/assets/49d34843-c181-448b-b9d3-5cb4380a1ad5" />




<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2025.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->