### PR TITLE
docs: add related content section to components guide

### DIFF
--- a/docs/conceptual-guides/components.md
+++ b/docs/conceptual-guides/components.md
@@ -204,3 +204,9 @@ Pull requests are welcome!
 - general zope events
 - lifecycle events
 - important events in plone
+
+## Related Content
+
+- [Choose a user interface](choose-user-interface.md)
+- [Distributions](distributions.md)
+- [Package management](package-management.md)


### PR DESCRIPTION
## First-time contributors

You **must** read and follow our [First-time contributors](https://6.docs.plone.org/contributing/first-time.html).

---

## Submit a pull request

Thank you for your contribution to the Plone Documentation.

Before submitting this pull request, please make sure you follow our guides:

-   [Contributing to Plone documentation](https://6.docs.plone.org/contributing/index.html)
-   [Building and checking the quality of documentation](https://6.docs.plone.org/contributing/documentation/setup-build.html)
-   [Authors guide](https://6.docs.plone.org/contributing/documentation/authors.html)
-   [MyST reference](https://6.docs.plone.org/contributing/documentation/myst-reference.html)

## Issue number
-Fixes #1973 
## Description

Adds a Related Content section to the Components conceptual guide to improve navigation between related documentation pages.


## Add screenshots or links to a preview of the changes
<img width="2730" height="1357" alt="image" src="https://github.com/user-attachments/assets/47d3442d-93aa-4e4b-99ad-de8616b2af8d" />



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2026.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->