### PR TITLE
Link Plone Training to official Plone 6 installation docs

### DIFF
--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -8,6 +8,6 @@ instructions.
 For supported and up-to-date installation methods, please refer to the
 authoritative Plone 6 documentation:
 
-https://6.docs.plone.org/install/
+{doc}`/install/index`
 
 See {doc}`training:index`.

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,12 +1,13 @@
----
-myst:
-  html_meta:
-    "description": "Plone Training"
-    "property=og:description": "Plone Training"
-    "property=og:title": "Plone Training"
-    "keywords": "Plone, Training"
----
-
 # Plone Training
+
+## Installation
+
+Plone Training materials intentionally do not include installation
+instructions.
+
+For supported and up-to-date installation methods, please refer to the
+authoritative Plone 6 documentation:
+
+https://6.docs.plone.org/install/
 
 See {doc}`training:index`.

--- a/docs/training/index.md
+++ b/docs/training/index.md
@@ -1,3 +1,12 @@
+---
+myst:
+  html_meta:
+    "description": "Plone Training"
+    "property=og:description": "Plone Training"
+    "property=og:title": "Plone Training"
+    "keywords": "Plone, Training"
+---
+
 # Plone Training
 
 ## Installation


### PR DESCRIPTION
Fixes plone/training#991

Add a clear reference from the training documentation to the
authoritative Plone 6 installation documentation to avoid
duplicating installation instructions.


<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2028.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->