### PR TITLE
Added related content to backend docs

### DIFF
--- a/docs/backend/indexing.md
+++ b/docs/backend/indexing.md
@@ -230,4 +230,3 @@ Indexes the `Subject` field which contains a list of object categories.
 ## Related content
 
 -   {doc}`/backend/search`
--   {doc}`/backend/content-types/index`

--- a/docs/backend/indexing.md
+++ b/docs/backend/indexing.md
@@ -226,3 +226,8 @@ Indexes the object path, such as `/news/news-item-1`.
 ## `Subject` (`KeywordIndex`)
 
 Indexes the `Subject` field which contains a list of object categories.
+
+## Related content
+
+-   {doc}`/backend/search`
+-   {doc}`/backend/content-types/index`

--- a/docs/backend/search.md
+++ b/docs/backend/search.md
@@ -38,4 +38,3 @@ Help us [Migrate content from v5 "Queries, Search And Indexing" #1730](https://g
 ## Related content
 
 -   {doc}`/backend/indexing`
--   {doc}`/backend/content-types/index`

--- a/docs/backend/search.md
+++ b/docs/backend/search.md
@@ -35,3 +35,7 @@ Help us [Migrate content from v5 "Queries, Search And Indexing" #1730](https://g
 
 ## Querystring
 
+## Related content
+
+-   {doc}`/backend/indexing`
+-   {doc}`/backend/content-types/index`

--- a/docs/backend/subscribers.md
+++ b/docs/backend/subscribers.md
@@ -170,3 +170,7 @@ The DCWorkflow events are low-level events that can tell you a lot about the pre
 `zope.processlifetime.IProcessStarting` is triggered after the component registry has been loaded and Zope is starting up.
 
 `zope.processlifetime.IDatabaseOpened` is triggered after the main ZODB database has been opened.
+
+## Related content
+
+-   {doc}`/backend/content-types/index`

--- a/docs/backend/subscribers.md
+++ b/docs/backend/subscribers.md
@@ -173,4 +173,6 @@ The DCWorkflow events are low-level events that can tell you a lot about the pre
 
 ## Related content
 
+-   {doc}`/backend/behaviors`
 -   {doc}`/backend/content-types/index`
+

--- a/docs/backend/traversal-acquisition.md
+++ b/docs/backend/traversal-acquisition.md
@@ -30,7 +30,7 @@ If not explicitly given, at the end a default view is looked up.
 This can be a registered page template, a callable view class, or a REST API endpoint.
 
 ```{seealso}
-{ref}`Chapter Views <classic-ui-views-label>`
+{doc}`/classic-ui/views`
 ```
 
 In code, traversal can be achieved by using the `restrictedTraverse` and `unrestrictedTraverse` methods of content objects.

--- a/docs/backend/traversal-acquisition.md
+++ b/docs/backend/traversal-acquisition.md
@@ -87,3 +87,8 @@ For example, if object `A` contains object `B`, and object `A` has a property `x
 -   About traversal: [Zope Developers Handbook, Chapter Object Publishing](https://zope.readthedocs.io/en/latest/zdgbook/ObjectPublishing.html)
 -   About acquisition: [Zope Developers Handbook, Chapter Acquisition](https://zope.readthedocs.io/en/latest/zdgbook/Acquisition.html)
 ```
+
+## Related content
+
+-   {doc}`/classic-ui/views`
+-   {doc}`/backend/zodb`

--- a/docs/backend/traversal-acquisition.md
+++ b/docs/backend/traversal-acquisition.md
@@ -90,5 +90,7 @@ For example, if object `A` contains object `B`, and object `A` has a property `x
 
 ## Related content
 
+-   {doc}`/backend/portal-actions`
+-   {doc}`/backend/security`
 -   {doc}`/classic-ui/views`
--   {doc}`/backend/zodb`
+

--- a/docs/backend/zodb.md
+++ b/docs/backend/zodb.md
@@ -74,8 +74,3 @@ Indexing and caching
 ## Further reading
 
 More information can be found at the official [ZODB website](https://zodb.org/en/latest/).
-
-## Related content
-
--   {doc}`/deployment/components`
--   {doc}`/admin-guide/configure-zope`

--- a/docs/backend/zodb.md
+++ b/docs/backend/zodb.md
@@ -74,3 +74,8 @@ Indexing and caching
 ## Further reading
 
 More information can be found at the official [ZODB website](https://zodb.org/en/latest/).
+
+## Related content
+
+-   {doc}`/deployment/components`
+-   {doc}`/admin-guide/configure-zope`

--- a/docs/classic-ui/forms.md
+++ b/docs/classic-ui/forms.md
@@ -276,7 +276,6 @@ In your `configure.zcml`:
 
 ## Related content
     
--   {doc}`/backend/schemas`
--   {doc}`/classic-ui/layers`
 -   {doc}`/backend/fields`
+-   {doc}`/backend/schemas`
 -   {doc}`/backend/widgets`

--- a/docs/classic-ui/forms.md
+++ b/docs/classic-ui/forms.md
@@ -273,3 +273,10 @@ In your `configure.zcml`:
 
 </configure>
 ```
+
+## Related content
+    
+-   {doc}`/backend/schemas`
+-   {doc}`/classic-ui/layers`
+-   {doc}`/backend/fields`
+-   {doc}`/backend/widgets`

--- a/docs/classic-ui/layers.md
+++ b/docs/classic-ui/layers.md
@@ -317,6 +317,7 @@ directlyProvides(self.portal.REQUEST, IThemeLayer)
 
 ## Related content
     
--   {doc}`/classic-ui/views`
+-   {doc}`/classic-ui/theming/index`
+-   {doc}`/classic-ui/theming/create-add-on`
+-   {doc}`/classic-ui/templates`
 -   {doc}`/classic-ui/viewlets`
--   {doc}`/admin-guide/add-ons`

--- a/docs/classic-ui/layers.md
+++ b/docs/classic-ui/layers.md
@@ -314,3 +314,9 @@ from zope.interface import directlyProvides
 
 directlyProvides(self.portal.REQUEST, IThemeLayer)
 ```
+
+## Related content
+    
+-   {doc}`/classic-ui/views`
+-   {doc}`/classic-ui/viewlets`
+-   {doc}`/admin-guide/add-ons`

--- a/docs/classic-ui/viewlets.md
+++ b/docs/classic-ui/viewlets.md
@@ -1051,6 +1051,8 @@ def fix_tinymce_viewlets(site):
 
 ## Related content
    
--   {doc}`/classic-ui/views`
 -   {doc}`/classic-ui/layers`
+-   {doc}`/classic-ui/templates`
+-   {doc}`/classic-ui/views`
+
 

--- a/docs/classic-ui/viewlets.md
+++ b/docs/classic-ui/viewlets.md
@@ -1048,3 +1048,9 @@ def fix_tinymce_viewlets(site):
     hidden = (x for x in hidden if x != "tinymce.configuration")
     storage.setHidden(manager, skinname, hidden)
 ```
+
+## Related content
+   
+-   {doc}`/classic-ui/views`
+-   {doc}`/classic-ui/layers`
+

--- a/docs/classic-ui/views.md
+++ b/docs/classic-ui/views.md
@@ -1124,5 +1124,6 @@ One workaround to avoid this mess is to use `aq_inner` when accessing `self.obj`
 
 ## Related content
 
--   {doc}`/classic-ui/viewlets`
 -   {doc}`/classic-ui/layers`
+-   {doc}`/classic-ui/templates`
+-   {doc}`/classic-ui/viewlets`

--- a/docs/classic-ui/views.md
+++ b/docs/classic-ui/views.md
@@ -1121,3 +1121,8 @@ return self.obj.absolute_url()  # Acquistion chain messed up, getPhysicalPath() 
 ```
 
 One workaround to avoid this mess is to use `aq_inner` when accessing `self.obj` values, as described in [Dealing with view implicit acquisition problems in Plone](https://stackoverflow.com/questions/11753940/dealing-with-view-implicit-acquisition-problems-in-plone/11755348#11755348).
+
+## Related content
+
+-   {doc}`/classic-ui/viewlets`
+-   {doc}`/classic-ui/layers`


### PR DESCRIPTION


## Issue number

- Fixes #1973 

### 1. `backend/indexing.md`

### Related content
`/backend/search`
`/backend/content-types/index`

Why - indexing takes data from content type fields and builds the catalog used by search.  
linking to content types shows where indexed data comes from , and linking to search shows how that data is used.


 2. `backend/search.md`

Related content
- `/backend/indexing`
- `/backend/content-types/index`

 Why
Search queries the catalog built by indexing, and indexing depends on fields and behaviors defined on content types.  
These links show what data is searchable and where it comes from.

 3. `backend/subscribers.md`

### Related content
`/backend/workflows`
/backend/content-types/index

Why
Subscribers react to lifecycle events on content objects.  
Workflows trigger those events, and content types define which objects they apply to.

 4. `backend/traversal-acquisition.md`

### Related content
   `/classic-ui/views`
`/backend/zodb`

Traversal resolves URLs to objects and views by walking the object tree stored in the ZODB.  
These links connect request routing, storage, and rendering.

5. `backend/zodb.md`

### Related content
`/deployment/components`
 `/admin-guide/configure-zope`

 Why- ZODB is the storage layer that affects how Plone is configured, deployed, and run in production.




<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2032.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->