### PR TITLE
Docs: use HTTPS for mfabrik link in viewlets example

### DIFF
--- a/docs/classic-ui/viewlets.md
+++ b/docs/classic-ui/viewlets.md
@@ -215,7 +215,7 @@ For a somewhat more recent example, see {doc}`training-2023:mastering-plone-5/vi
 ```python
 """
 Facebook like viewlet for Plone.
-http://mfabrik.com
+https://mfabrik.com
 """
 
 import urllib


### PR DESCRIPTION
## Issue number
- N/A

## Description
Updated the external mfabrik link in the classic UI viewlets example to use HTTPS.

This is a small documentation-only change. No changes were made to localhost examples or the legacy Facebook-related code blocks.

## Add screenshots or links to a preview of the changes
- N/A (documentation link update only)



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2033.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->