### PR TITLE
Added sphinx-llms-txt extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_examples",
+    "sphinx_llms_txt",
     "sphinx_reredirects",
     "sphinx_sitemap",
     "sphinx_tippy",
@@ -204,8 +205,8 @@ html_theme_options = {
             "attributes": {
                 "target": "_blank",
                 "rel": "noopener me",
-                "class": "nav-link custom-fancy-css"
-            }
+                "class": "nav-link custom-fancy-css",
+            },
         },
         {
             "name": "Mastodon",
@@ -215,8 +216,8 @@ html_theme_options = {
             "attributes": {
                 "target": "_blank",
                 "rel": "noopener me",
-                "class": "nav-link custom-fancy-css"
-            }
+                "class": "nav-link custom-fancy-css",
+            },
         },
         {
             "name": "YouTube",
@@ -226,8 +227,8 @@ html_theme_options = {
             "attributes": {
                 "target": "_blank",
                 "rel": "noopener me",
-                "class": "nav-link custom-fancy-css"
-            }
+                "class": "nav-link custom-fancy-css",
+            },
         },
         {
             "name": "X (formerly Twitter)",
@@ -237,8 +238,8 @@ html_theme_options = {
             "attributes": {
                 "target": "_blank",
                 "rel": "noopener me",
-                "class": "nav-link custom-fancy-css"
-            }
+                "class": "nav-link custom-fancy-css",
+            },
         },
     ],
     "logo": {
@@ -453,6 +454,7 @@ latex_logo = "_static/logo_2x.png"
 
 # --  Configuration for source_replacements extension -----------------------
 
+
 # An extension that allows replacements for code blocks that
 # are not supported in `rst_epilog` or other substitutions.
 # https://stackoverflow.com/a/56328457/2214933
@@ -467,6 +469,7 @@ def source_replace(app, docname, source):
 source_replacements = {
     "{PLONE_BACKEND_MINOR_VERSION}": "6.1",
 }
+
 
 # Finally, configure app attributes.
 def setup(app):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ sphinx-autobuild
 sphinx-copybutton
 sphinx-design  # Documentation only
 sphinx-examples
+sphinx-llms-txt
 sphinx-notfound-page  # Documentation only
 sphinx-reredirects
 sphinx-sitemap


### PR DESCRIPTION
closes #2016 

It generates the `llms.txt` out of the index.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2034.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->