### PR TITLE
Pin `sphinx<9` as a temporary workaround

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 linkify-it-py
 plone-sphinx-theme<2
+sphinx<9  # See https://github.com/plone/documentation/issues/2037
 sphinx-autobuild
 sphinx-copybutton
 sphinx-design  # Documentation only


### PR DESCRIPTION
Fixes #2036.

See also #2037.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2038.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->