### PR TITLE
Include Diazo documentation in Classic backend documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 docs/plone.api
 docs/plone.restapi
 docs/volto
+docs/diazo
 
 # editor files
 .vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
 	path = submodules/plone.api
 	url = https://github.com/plone/plone.api.git
 	branch = main
+[submodule "submodules/diazo"]
+	path = submodules/diazo
+	url = https://github.com/plone/diazo.git
+	branch = main

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ distclean: clean ## Clean Python virtual environment and symlinks to submodules
 	rm docs/plone.api
 	rm docs/plone.restapi
 	rm docs/volto
+	rm docs/diazo
 	@echo "Cleaned Python virtual environment and symlinks to submodules."
 	@echo
 
@@ -73,6 +74,13 @@ docs/volto:  ## Setup Volto docs
 	@echo "Documentation of volto initialized."
 	@echo
 
+docs/diazo:  ## Setup diazo docs
+	git submodule init
+	git submodule update
+	ln -s ../submodules/diazo/docs ./docs/diazo
+	@echo "Documentation of diazo initialized."
+	@echo
+
 ln-seven:  ## Toggle the symlink to Seven
 	rm docs/volto
 	ln -s ../submodules/volto/docs ./docs/volto
@@ -86,7 +94,7 @@ ln-volto:  ## Toggle the symlink to Volto
 	@echo
 
 .PHONY: deps
-deps: venv/bin/python docs/volto docs/plone.restapi venv/plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
+deps: venv/bin/python docs/volto docs/plone.restapi docs/diazo venv/plone.api-install  ## Create Python virtual environment, install requirements, initialize or update the volto, plone.restapi, diazo, and plone.api submodules, create symlinks to the source files, and finally install plone.api.
 
 .PHONY: html
 html: deps  ## Build html
@@ -233,6 +241,7 @@ livehtml: deps  ## Rebuild Sphinx documentation on changes, with live-reload in 
 		--watch volto \
 		--watch plone.api \
 		--watch plone.restapi \
+		--watch diazo \
 		-b html . "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
 
 .PHONY: rtd-pr-preview
@@ -246,6 +255,7 @@ rtd-pr-preview:  ## Build pull request preview on Read the Docs
 	ln -s ../submodules/volto/docs/source ./docs/volto
 	ln -s ../submodules/plone.restapi ./docs/plone.restapi
 	ln -s ../submodules/plone.api/docs ./docs/plone.api
+	ln -s ../submodules/diazo/docs ./docs/diazo
 	cd $(DOCS_DIR) && sphinx-build -b html $(ALLSPHINXOPTS) ${READTHEDOCS_OUTPUT}/html/
 
 .PHONY: storybook

--- a/docs/classic-ui/index.md
+++ b/docs/classic-ui/index.md
@@ -34,6 +34,7 @@ static-resources
 template-global-variables
 templates
 theming/index
+../diazo/index
 tinymce-customization
 viewlets
 views

--- a/docs/classic-ui/theming/diazo.md
+++ b/docs/classic-ui/theming/diazo.md
@@ -166,7 +166,7 @@ Add a stanza in your {file}`rules.xml` file.
 
 You can start with the provided {file}`rules.xml` file.
 
-You can read about how to write your rules and their syntax in the [official Diazo documentation](https://docs.diazo.org/en/latest/basic.html).
+You can read about how to write your rules and their syntax in the {doc}`Diazo documentation </diazo/index>`.
 
 You will need to write your own rules to bring the dynamic content from Plone into the theme.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,6 +160,20 @@ exclude_patterns = [
     "plone.restapi/styles",
     "plone.restapi/var",
     "volto/_inc/*",
+    "diazo/CHANGES.rst",
+    "diazo/CONTRIBUTING.rst",
+    "diazo/LICENSE.txt",
+    "diazo/MANIFEST.in",
+    "diazo/README.rst",
+    "diazo/pyproject.toml",
+    "diazo/setup.cfg",
+    "diazo/setup.py",
+    "diazo/tox.ini",
+    "diazo/examples",
+    "diazo/src",
+    "diazo/news",
+    "diazo/oldchanges.rst",
+    "diazo/TODO.txt",
 ]
 
 suppress_warnings = [

--- a/docs/contributing/documentation/index.md
+++ b/docs/contributing/documentation/index.md
@@ -69,12 +69,13 @@ Plone documentation consists of several repositories.
 -   [`plone.api`](https://github.com/plone/plone.api)
 -   [`plone.restapi`](https://github.com/plone/plone.restapi)
 -   [`volto`](https://github.com/plone/volto)
+-   [`diazo`](https://github.com/plone/diazo)
 
 [`documentation`](https://github.com/plone/documentation) is the primary repository.
 When you {doc}`setup and build <setup-build>` the documentation, it will automatically pull in the other repositories via git submodules.
 
 ```{important}
-We currently use the branches `plone/documentation@6.0`, `plone/plone.api@main`, `plone/plone.restapi@main`, and `plone/volto@main` as the default branches for developing Plone 6 Documentation.
+We currently use the branches `plone/documentation@6.0`, `plone/plone.api@main`, `plone/plone.restapi@main`, `plone/volto@main`, and `plone/diazo@main` as the default branches for developing Plone 6 Documentation.
 ```
 
 
@@ -241,7 +242,7 @@ This section describes how to make contributions to files in the `plone/document
 
 ### Editing external package documentation
 
-To edit documentation of imported external packages, including `plone/plone.api`, `plone/plone.restapi`, and `plone/volto`, the process is slightly different.
+To edit documentation of imported external packages, including `plone/plone.api`, `plone/plone.restapi`, `plone/volto`, and `plone/diazo`, the process is slightly different.
 Plone Documentation uses git submodules to manage multiple repositories.
 You already imported the external repositories into the `plone/documentation` repository as described in {doc}`setup-build`.
 
@@ -252,6 +253,7 @@ You already imported the external repositories into the `plone/documentation` re
     cd submodules/plone.api/docs
     cd submodules/plone.restapi/docs/source
     cd submodules/volto/docs/source
+    cd submodules/diazo/docs
     ```
 
 1.  Sync your local development branch with its remote.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -206,6 +206,10 @@ Volto
 :   Plone 6 default frontend.
     See {doc}`../volto/contributing/index`.
 
+Diazo
+:   Theme engine for Plone.
+    See the [Diazo documentation](https://docs.diazo.org/).
+
 (contributing-releases-label)=
 
 ## Releases


### PR DESCRIPTION
## Issue number 

- Fixes #2044.

## Description
Adds Diazo documentation to the Plone Classic backend documentation for better visibility and maintenance.

## Add screenshots or links to a preview of the changes

<img width="1804" height="846" alt="screenshot-2026-02-07_17-22-27" src="https://github.com/user-attachments/assets/02ace758-e96e-4676-a07f-f5a7a6053494" />

---

<img width="1809" height="832" alt="screenshot-2026-02-07_17-22-36" src="https://github.com/user-attachments/assets/1c658b73-0ed8-43f9-b1bb-381ddec272a7" />



<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2051.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->