### PR TITLE
Resource registry: Document the `*` depends value.

### DIFF
--- a/docs/classic-ui/static-resources.md
+++ b/docs/classic-ui/static-resources.md
@@ -102,6 +102,7 @@ The following attributes are available for registering a static resource.
 
     The `depends` attribute may be assigned the value of `all`, making this bundle render last, after all other bundles.
     The `all` value lets you load CSS files after the automatically added theme resources and override CSS declarations from your own custom CSS files.
+    `*` is an alias for `all`, so you can also use that.
 
     If you set multiple bundles to `all`, then these bundles will render in alphabetical order by its name.
 
@@ -113,6 +114,11 @@ The following attributes are available for registering a static resource.
 
     ```{versionadded} Plone 6.0.14
     `depends` value of `all`.
+    ```
+
+    ```{versionadded} Plone 6.2.0a2
+    `depends` value of `*`.
+    Note: The `*` value was present in Plone < 6.
     ```
 
 `load_async`


### PR DESCRIPTION
Documentation of the feature from https://github.com/plone/Products.CMFPlone/pull/4274

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2052.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->