### PR TITLE
Fix broken links from recent Classic UI and Backend documentation

### DIFF
--- a/docs/backend/vocabularies.md
+++ b/docs/backend/vocabularies.md
@@ -663,17 +663,12 @@ The response includes the `token` and `title` for each term:
 7. **Document your vocabularies** with docstrings explaining what they contain and when to use them.
 
 
-## See Also
-
-- {ref}`fields-label` for field types that use vocabularies
-- {doc}`../forms/index` for form handling
-- [zope.schema documentation](https://zopeschema.readthedocs.io/)
-- [plone.app.vocabularies source code](https://github.com/plone/plone.app.vocabularies)
-- [bobtemplates.plone documentation](https://bobtemplatesplone.readthedocs.io/)
-
-
 ## Related content
 
--   {doc}`/backend/fields`
+-   {doc}`/backend/fields` for field types that use vocabularies
+-   {doc}`classic-ui/forms` for form handling
+-   [`zope.schema documentation`](https://zopeschema.readthedocs.io/)
+-   [`plone.app.vocabularies` source code](https://github.com/plone/plone.app.vocabularies)
+-   [`bobtemplates.plone` documentation](https://bobtemplatesplone.readthedocs.io/)
 -   {doc}`/backend/schemas`
 -   {doc}`/backend/content-types/index`

--- a/docs/classic-ui/views.md
+++ b/docs/classic-ui/views.md
@@ -717,7 +717,7 @@ However, in most cases:
     You get the HTML output with `self.index()`.
     The page template gets a context argument `view`, pointing to the view class instance.
     The `index` value is usually an instance of [`Products.Five.browser.pagetemplate.ViewPageTemplateFile`](https://github.com/zopefoundation/Zope/blob/d1814d0a6bddb615629b552de10e9aa5ad30a6da/src/Products/Five/browser/pagetemplatefile.py#L35) for full Plone pages or [`zope.pagetemplate.pagetemplatefile.PageTemplateFile`](https://github.com/zopefoundation/zope.pagetemplate/blob/14ba59c98e12517b9f8abcdb24bc882bb435ed7c/src/zope/pagetemplate/pagetemplatefile.py#L43) for HTML snippets without using acquisition.
--   View classes should implement the {doc}`interface </backend/interfaces>`
+-   View classes should implement the {ref}`interface <classic-ui-register-and-unregister-a-view-directly-using-zope.component-architecture-label>`
   [`zope.browser.interfaces.IBrowserView`](https://github.com/zopefoundation/zope.browser/blob/1239c75e4e190df992bf34a88b4ead2c952afe86/src/zope/browser/interfaces.py#L27).
 
 Views that render page snippets and parts can be direct subclasses of `zope.publisher.browser.BrowserView`, as snippets might not need acquisition support which adds some overhead to the rendering process.


### PR DESCRIPTION
@MrTango would you please check this links? I made a best guess, but I'm not sure where you got the original link or reference.

Also @davisagli made some comments in https://github.com/plone/documentation/pull/2056#pullrequestreview-3823240798 that introduced some issues that should be resolved. Would you please take care?

Thank you!

- https://github.com/plone/documentation/pull/2056/
- https://github.com/plone/documentation/pull/2057/

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2075.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->