### PR TITLE
Prepare for Plone 6.2 release v2

### DIFF
--- a/docs/_inc/_install-python-plone62.md
+++ b/docs/_inc/_install-python-plone62.md
@@ -1,0 +1,9 @@
+Installing Python is beyond the scope of this documentation.
+However, it is recommended to use a Python version manager, such as {term}`uv` or {term}`pyenv`, that allows you to install multiple versions of Python on your development environment without destroying your system's Python.
+
+```{warning}
+Do not create or activate a Python virtual environment at this time.
+The instructions below will create one.
+```
+
+Plone 6.2 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}.

--- a/docs/admin-guide/install-buildout.md
+++ b/docs/admin-guide/install-buildout.md
@@ -31,12 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   For Plone 6.2, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone61.md
+```{include} /_inc/_install-python-plone62.md
 ```
 
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,12 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.1, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   For Plone 6.2, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone61.md
+```{include} /_inc/_install-python-plone62.md
 ```
 
 

--- a/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
+++ b/docs/backend/upgrading/version-specific-migration/upgrade-to-62.md
@@ -15,6 +15,11 @@ Plone 6.2 has seen the following major changes.
 Some may require changes in your setup.
 
 
+## Added support for Python 3.14
+
+Plone 6.2 supports Python 3.14.
+
+
 ## Move to native namespaces
 
 Plone 6.2 has migrated all core Python packages from `pkg_resources`-style namespaces to native namespaces.
@@ -36,11 +41,9 @@ The two terms mean the same.
 ```
 
 Native namespaces exist since Python 3.3.
-Because Plone started in the days of Python 2, it has always used `pkg_resources`.
-`pkg_resources` is part of the `setuptools` package.
-This part is deprecated.
-It's scheduled to be removed around the end of 2025, in `setuptools` 81.
-This means Plone needs to move to native namespaces.
+Because Plone started in the days of Python 2, it has always used `pkg_resources`, until now.
+[`pkg_resources` was removed from `setuptools` 82.0.0](https://setuptools.pypa.io/en/latest/history.html#v82-0-0).
+This means Plone needed to move to native namespaces.
 
 In general, this move shouldn't cause problems for integrators.
 To install Plone 6.2 you can keep using the same version of `pip` (or `uv`), or `zc.buildout` as you do for Plone 6.1.
@@ -84,6 +87,13 @@ Templates from the following packages are now in a new location:
 
 * `plone.locking`
 * `plone.protect`
+
+Starting with Plone 6.2, you can activate plone.app.layout in the {guilabel}`Add-ons` control panel.
+
+If you use Classic UI, you should activate it.
+If you use Volto, you should not activate it.
+
+The automatic upgrade attempts to activate plone.app.layout according to your original configuration, but you should check the {guilabel}`Add-ons` control panel to make sure.
 
 ```{note}
 If you use the `z3c.jbot` add-on to override a template that has been moved, your override will still work.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -325,7 +325,7 @@ myst_substitutions = {
     "fawrench": '<span class="fa fa-wrench" style="font-size: 1.6em;"></span>',
     "SUPPORTED_PYTHON_VERSIONS_PLONE60": "3.9, 3.10, 3.11, 3.12, or 3.13",
     "SUPPORTED_PYTHON_VERSIONS_PLONE61": "3.10, 3.11, 3.12, or 3.13",
-    "SUPPORTED_PYTHON_VERSIONS_PLONE62": "3.10, 3.11, 3.12, or 3.13",
+    "SUPPORTED_PYTHON_VERSIONS_PLONE62": "3.10, 3.11, 3.12, 3.13, or 3.14",
 }
 
 

--- a/docs/contributing/core/index.md
+++ b/docs/contributing/core/index.md
@@ -48,7 +48,7 @@ However, the following links and sections below may be helpful.
 
 Installing Python is beyond the scope of this documentation.
 However, it is recommended to use a Python version manager, {term}`pyenv` that allows you to install multiple versions of Python on your development environment without destroying your system's Python.
-Plone requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}.
+Plone requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}.
 
 
 ### Make

--- a/docs/contributing/documentation/setup-build.md
+++ b/docs/contributing/documentation/setup-build.md
@@ -22,7 +22,7 @@ Installation of Plone 6 Documentation includes prerequisites and the repository 
 
 ```{include} ../../volto/_inc/_install-operating-system.md
 ```
--   {ref}`setup-build-installation-python-label` {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   {ref}`setup-build-installation-python-label` {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
 -   {ref}`setup-build-installation-gnu-make-label`
 -   {ref}`setup-build-installation-graphviz-label`
 
@@ -31,7 +31,7 @@ Installation of Plone 6 Documentation includes prerequisites and the repository 
 
 ### Python
 
-```{include} /_inc/_install-python-plone61.md
+```{include} /_inc/_install-python-plone62.md
 ```
 
 (setup-build-installation-gnu-make-label)=


### PR DESCRIPTION
Supersedes #2071 without a submodule.

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2080.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->