### PR TITLE
Update Node.js version to 22.x in workflow

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -6,7 +6,7 @@ on:
       - "6.0"
 
 env:
-  node-version: 20.x
+  node-version: 22.x
 
 jobs:
   build_deploy:


### PR DESCRIPTION
Because it falls down and can't get up.

https://github.com/plone/documentation/actions/runs/25661079082/job/75325751956#step:10:14

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2082.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->