### PR TITLE
Prepare for 6.3 final release

### DIFF
--- a/docs/_inc/_install-python-plone63.md
+++ b/docs/_inc/_install-python-plone63.md
@@ -1,0 +1,9 @@
+Installing Python is beyond the scope of this documentation.
+However, it is recommended to use a Python version manager, such as {term}`uv` or {term}`pyenv`, that allows you to install multiple versions of Python on your development environment without destroying your system's Python.
+
+```{warning}
+Do not create or activate a Python virtual environment at this time.
+The instructions below will create one.
+```
+
+Plone 6.3 requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}.

--- a/docs/admin-guide/install-buildout.md
+++ b/docs/admin-guide/install-buildout.md
@@ -31,12 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.2, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
+-   For Plone 6.3, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone62.md
+```{include} /_inc/_install-python-plone63.md
 ```
 
 

--- a/docs/admin-guide/install-pip.md
+++ b/docs/admin-guide/install-pip.md
@@ -31,12 +31,12 @@ For other installation options, see {ref}`get-started-install-label`.
 
 ## Prerequisites for installation
 
--   For Plone 6.2, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
+-   For Plone 6.3, Python {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}
 
 
 ### Python
 
-```{include} /_inc/_install-python-plone62.md
+```{include} /_inc/_install-python-plone63.md
 ```
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -326,6 +326,7 @@ myst_substitutions = {
     "SUPPORTED_PYTHON_VERSIONS_PLONE60": "3.9, 3.10, 3.11, 3.12, or 3.13",
     "SUPPORTED_PYTHON_VERSIONS_PLONE61": "3.10, 3.11, 3.12, or 3.13",
     "SUPPORTED_PYTHON_VERSIONS_PLONE62": "3.10, 3.11, 3.12, 3.13, or 3.14",
+    "SUPPORTED_PYTHON_VERSIONS_PLONE63": "3.11, 3.12, 3.13, or 3.14",
 }
 
 
@@ -474,7 +475,7 @@ def source_replace(app, docname, source):
 
 # Dict of replacements.
 source_replacements = {
-    "{PLONE_BACKEND_MINOR_VERSION}": "6.2",
+    "{PLONE_BACKEND_MINOR_VERSION}": "6.3",
 }
 
 

--- a/docs/contributing/core/index.md
+++ b/docs/contributing/core/index.md
@@ -38,7 +38,7 @@ However, the following links and sections below may be helpful.
 ```{include} ../../volto/_inc/_install-operating-system.md
 ```
 
--   Python {{SUPPORTED_PYTHON_VERSIONS_PLONE61}}
+-   Python {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}
 -   {term}`GNU make`
 -   {term}`Git`
 -   A C compiler
@@ -48,7 +48,7 @@ However, the following links and sections below may be helpful.
 
 Installing Python is beyond the scope of this documentation.
 However, it is recommended to use a Python version manager, {term}`pyenv` that allows you to install multiple versions of Python on your development environment without destroying your system's Python.
-Plone requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}.
+Plone requires Python version {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}.
 
 
 ### Make

--- a/docs/contributing/documentation/setup-build.md
+++ b/docs/contributing/documentation/setup-build.md
@@ -22,7 +22,7 @@ Installation of Plone 6 Documentation includes prerequisites and the repository 
 
 ```{include} ../../volto/_inc/_install-operating-system.md
 ```
--   {ref}`setup-build-installation-python-label` {{SUPPORTED_PYTHON_VERSIONS_PLONE62}}
+-   {ref}`setup-build-installation-python-label` {{SUPPORTED_PYTHON_VERSIONS_PLONE63}}
 -   {ref}`setup-build-installation-gnu-make-label`
 -   {ref}`setup-build-installation-graphviz-label`
 
@@ -31,7 +31,7 @@ Installation of Plone 6 Documentation includes prerequisites and the repository 
 
 ### Python
 
-```{include} /_inc/_install-python-plone62.md
+```{include} /_inc/_install-python-plone63.md
 ```
 
 (setup-build-installation-gnu-make-label)=

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -19,6 +19,7 @@ Plone has several components, each of which have their own upgrade guides:
 
 For Plone 6 the most relevant guides are:
 
+-   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-63`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-62`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-61`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-60`

--- a/docs/upgrade/index.md
+++ b/docs/upgrade/index.md
@@ -19,7 +19,6 @@ Plone has several components, each of which have their own upgrade guides:
 
 For Plone 6 the most relevant guides are:
 
--   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-63`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-62`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-61`
 -   {doc}`../backend/upgrading/version-specific-migration/upgrade-to-60`


### PR DESCRIPTION
Do not merge until the final release of Plone 6.3 has been made.

- In plone/documentation's conf.py update PLONE_BACKEND_MINOR_VERSION.
- In plone/documentation's conf.py update SUPPORTED_PYTHON_VERSIONS_PLONE##.
- Create a new include file docs/_inc/_install-python-plone##.md, and update its content.
- Update files that use these substitutions and includes.

Ref: https://github.com/plone/Products.CMFPlone/issues/4328#issuecomment-4518248113

<!-- readthedocs-preview plone6 start -->
----
📚 Documentation preview 📚: https://plone6--2086.org.readthedocs.build/

<!-- readthedocs-preview plone6 end -->